### PR TITLE
[docs] Add comprehensive documentation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ For the test folder organization, see `tests/` (`mlir/`, `pyir/`, `kernels/`).
   - Add MLIR build lib dir to the loader path:
     - `export LD_LIBRARY_PATH=$MLIR_PATH/lib:$LD_LIBRARY_PATH`
 
+## Documentation
+
+| **Topic** | **Description** | **Guide** |
+|---|---|---|
+| Architecture | Compilation pipeline, project structure, environment config | [Architecture Guide](docs/architecture_guide.md) |
+| Layout System | FLIR layout algebra — Shape, Stride, Layout, Coord, all operations | [Layout Guide](docs/layout_system_guide.md) |
+| Kernel Authoring | Writing GPU kernels — MlirModule, tiled copies, MFMA, shared memory | [Kernel Guide](docs/kernel_authoring_guide.md) |
+| Pre-built Kernels | Available kernels — GEMM, MoE, Softmax, Norm — config and usage | [Kernels Reference](docs/prebuilt_kernels_guide.md) |
+| Testing & Benchmarks | Test infrastructure, benchmarking, performance comparison | [Testing Guide](docs/testing_benchmarking_guide.md) |
+| CuteDSL → FlyDSL | Porting from NVIDIA CuteDSL to FlyDSL — concept mapping, code examples | [Porting Guide](docs/cutedsl_to_flydsl_porting_guide.md) |
+
 ## 📐 FLIR Layout System
 
 > FLIR = **F**lexible **L**ayout **I**ntermediate **R**epresentation.

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -1,0 +1,353 @@
+# Architecture & Compilation Pipeline Guide
+
+> FlyDSL project structure, compilation stages, key abstractions, and configuration.
+
+## Quick Reference
+
+| Component | Description | Key File |
+|---|---|---|
+| **FlyDSL** | Python DSL front-end for authoring GPU kernels | `flydsl/src/flydsl/` |
+| **FLIR** | Flexible Layout IR -- MLIR dialect with layout algebra | `flir/` |
+| **Compiler** | `flir.compile()` -- end-to-end DSL-to-binary pipeline | `flydsl/src/flydsl/compiler/compiler.py` |
+| **Pipeline** | Fluent pass-pipeline builder | `flydsl/src/flydsl/compiler/pipeline.py` |
+| **Executor** | MLIR ExecutionEngine wrapper for JIT execution | `flydsl/src/flydsl/compiler/executor.py` |
+| **MlirModule** | Base class for kernel module authoring | `flydsl/src/flydsl/lang/ir/module.py` |
+
+---
+
+## 1. Project Structure
+
+```
+FlyDSL/
+├── flir/                          # C++ MLIR dialect + compiler infrastructure
+│   ├── include/flir/
+│   │   ├── FlirOps.td             # FLIR layout ops (make_shape, crd2idx, composition, ...)
+│   │   ├── FlirTypeDefs.td        # Custom types (!flir.shape, !flir.layout, ...)
+│   │   ├── FlirAttrDefs.td        # Attributes (#flir.underscore, #flir.dync_i32)
+│   │   ├── FlirPasses.td          # Pass declarations (flir-to-standard, trivial-dce)
+│   │   ├── FlirRocmOps.td         # ROCm ops (MFMA, LDS, copy, barriers)
+│   │   └── FlirRocmDialect.td     # ROCm dialect declaration
+│   ├── lib/Dialect/
+│   │   ├── Flir/
+│   │   │   ├── FlirOps.cpp        # Op verifiers and builders
+│   │   │   ├── FlirLayoutAlgebra.cpp  # Type inference for composition/product/divide
+│   │   │   └── FlirDialect.cpp    # Dialect registration
+│   │   └── FlirRocm/              # ROCm dialect implementation
+│   ├── lib/Transforms/
+│   │   ├── FlirToStandard.cpp     # flir-to-standard lowering pass
+│   │   └── FlirDCE.cpp            # trivial-dce pass
+│   ├── python_bindings/           # Python ↔ C++ bridge
+│   │   ├── dialects/flir.py       # Low-level Python bindings for FLIR ops
+│   │   └── FlirRegisterPasses.cpp # Register passes and dialects from Python
+│   ├── tools/flir-opt/            # CLI tool for running passes on .mlir files
+│   └── build.sh                   # Build script (CMake + ninja)
+│
+├── flydsl/                        # Python package (src layout)
+│   └── src/flydsl/
+│       ├── compiler/
+│       │   ├── compiler.py        # flir.compile() -- top-level compilation entry
+│       │   ├── pipeline.py        # Pipeline fluent API
+│       │   ├── executor.py        # ExecutionEngineExecutor (JIT runner)
+│       │   ├── context.py         # RAIIMLIRContext, RAIIMLIRContextModule
+│       │   ├── cache.py           # On-disk compilation cache
+│       │   └── flir_opt_helper.py # Helper for invoking flir-opt
+│       ├── dialects/ext/
+│       │   ├── flir.py            # High-level Python API for layout algebra
+│       │   ├── gpu.py             # GPU dialect extensions (launch, barrier, ...)
+│       │   ├── rocm.py            # ROCm dialect Python helpers
+│       │   ├── arith.py           # Arithmetic extensions
+│       │   └── ...                # scf, memref, vector, func, rocdl, ...
+│       ├── lang/ir/
+│       │   ├── module.py          # MlirModule base class, @kernel / @jit decorators
+│       │   └── types.py           # Type helpers
+│       ├── runtime/
+│       │   └── device.py          # get_rocm_arch() -- GPU architecture detection
+│       └── utils/
+│           └── smem_allocator.py  # SmemAllocator for LDS management
+│
+├── kernels/                       # Pre-built GPU kernels
+│   ├── preshuffle_gemm.py         # GEMM with B-preshuffle
+│   ├── mixed_preshuffle_gemm.py   # Mixed-precision GEMM (FP4/FP8)
+│   ├── moe_gemm_2stage.py         # MoE GEMM (2-stage)
+│   ├── mixed_moe_gemm_2stage.py   # Mixed MoE GEMM
+│   ├── layernorm_kernel.py        # LayerNorm
+│   ├── rmsnorm_kernel.py          # RMSNorm
+│   ├── softmax_kernel.py          # Softmax
+│   ├── reduce.py                  # Warp/block reduction primitives
+│   ├── mfma_epilogues.py          # MFMA result writeback patterns
+│   └── mfma_preshuffle_pipeline.py # Preshuffle helpers for MFMA kernels
+│
+├── tests/
+│   ├── pyir/                      # Python IR tests (no GPU required)
+│   ├── kernels/                   # GPU kernel tests + benchmarks
+│   └── test_common.py             # Shared test utilities
+│
+└── scripts/                       # Build and test helpers
+    ├── build_llvm.sh              # Build MLIR from ROCm llvm-project
+    ├── run_tests.sh               # Run all tests
+    └── run_benchmark.sh           # Run benchmarks
+```
+
+---
+
+## 2. Compilation Pipeline
+
+### 2.1 High-Level Flow
+
+```
+Python DSL (@kernel / @jit)
+        │
+        ▼
+   MLIR Module (FLIR dialect ops)
+        │
+        ▼  flir.compile()
+   ┌────────────────────────────────────────────┐
+   │  flir-to-standard                          │  FLIR → scf + arith + memref
+   │  trivial-dce                               │  Dead code elimination
+   │  canonicalize                              │  Standard MLIR canonicalization
+   │  cse                                       │  Common subexpression elimination
+   │  gpu-kernel-outlining                      │  Outline GPU kernels
+   │  gpu.module(convert-scf-to-cf)             │  SCF → ControlFlow (inside gpu.module)
+   │  gpu.module(convert-gpu-to-rocdl)          │  GPU → ROCDL (inside gpu.module)
+   │  gpu.module(reconcile-unrealized-casts)    │  Clean up casts
+   │  rocdl-attach-target{chip=gfxNNN}          │  Attach ROCm target
+   │  gpu-to-llvm                               │  GPU types → LLVM types
+   │  reconcile-unrealized-casts                │  Clean up remaining casts
+   │  gpu-module-to-binary{format=fatbin}       │  Emit HSACO binary
+   └────────────────────────────────────────────┘
+        │
+        ▼
+   ExecutionEngineExecutor (JIT runner)
+```
+
+### 2.2 Pipeline Stages in Detail
+
+The pipeline is defined in `compiler/compiler.py:_pipeline_fragments()`:
+
+| Stage | Pass | Description |
+|---|---|---|
+| 1 | `flir-to-standard` | Lowers all `flir.*` ops to standard MLIR (scf, arith, memref). Coordinate mapping (`crd2idx`, `idx2crd`) becomes arithmetic. Layout algebra ops are folded/lowered. |
+| 2 | `trivial-dce` | Removes trivially dead ops (no side effects, unused results). |
+| 3 | `canonicalize` | Standard MLIR canonicalization (constant folding, identity removal, etc.). |
+| 4 | `cse` | Common subexpression elimination. |
+| 5 | `gpu-kernel-outlining` | Moves GPU kernel bodies into `gpu.func` inside `gpu.module`. |
+| 6 | `convert-scf-to-cf` | Lowers `scf.for`/`scf.if` to `cf.br`/`cf.cond_br` (inside `gpu.module`). |
+| 7 | `convert-gpu-to-rocdl` | Converts `gpu.thread_id`, `gpu.block_id`, etc. to ROCDL intrinsics (inside `gpu.module`). |
+| 8 | `reconcile-unrealized-casts` | Cleans up unrealized conversion casts inside `gpu.module`. |
+| 9 | `rocdl-attach-target` | Attaches `#rocdl.target<chip=gfxNNN>` for the target GPU. |
+| 10 | `gpu-to-llvm` | Converts GPU-related types/ops to LLVM dialect (host-side launch infrastructure). |
+| 11 | `reconcile-unrealized-casts` | Final cast cleanup. |
+| 12 | `gpu-module-to-binary` | Compiles the GPU module to HSACO binary (embedded in the module as a blob). |
+
+### 2.3 Using the Pipeline API
+
+The `Pipeline` class provides a fluent builder:
+
+```python
+from flydsl.compiler.pipeline import Pipeline
+
+pipeline = (
+    Pipeline()
+    .flir_to_standard()
+    .canonicalize()
+    .cse()
+    .rocdl_attach_target(chip="gfx942")
+    .Gpu(Pipeline().convert_gpu_to_rocdl(runtime="HIP"))
+    .gpu_to_llvm()
+    .lower_to_llvm()
+    .gpu_module_to_binary(format="bin")
+)
+
+# Run pipeline on a module
+result = pipeline.run(module)
+
+# Or use the string representation
+print(pipeline)  # builtin.module(flir-to-standard,canonicalize,...)
+```
+
+Key `Pipeline` methods:
+- **FLIR passes**: `.flir_to_standard()`, `.flir_coord_lowering()` (alias)
+- **Optimization**: `.canonicalize()`, `.cse()`, `.inline()`, `.symbol_dce()`, `.sccp()`
+- **Conversion**: `.convert_scf_to_cf()`, `.convert_gpu_to_rocdl()`, `.gpu_to_llvm()`, `.lower_to_llvm()`
+- **Target**: `.rocdl_attach_target(chip=...)`, `.gpu_module_to_binary(format=...)`
+- **Nesting**: `.Gpu(nested_pipeline)`, `.Func(nested_pipeline)`, `.Module(nested_pipeline)`
+- **Composition**: `pipeline_a + pipeline_b`, `pipeline_a += pipeline_b`
+
+### 2.4 Using `flir.compile()`
+
+For most use cases, the high-level `flir.compile()` handles the full pipeline:
+
+```python
+from flydsl.compiler.compiler import compile
+
+# Compile and get an executor
+executor = compile(my_module, opt_level=3)
+
+# Call a kernel function
+executor.my_kernel(A, B, C)
+```
+
+`flir.compile()` automatically:
+1. Detects the target GPU architecture (or reads `ARCH` env var)
+2. Overrides `gpu.module` targets consistently
+3. Checks the on-disk cache (can skip recompilation)
+4. Runs the full pipeline
+5. Returns an `ExecutionEngineExecutor` (or `None` if `COMPILE_ONLY=1`)
+
+---
+
+## 3. Key Abstractions
+
+### 3.1 `RAIIMLIRContextModule`
+
+Sets up an MLIR context with FLIR dialects registered, a default location, a module, and an insertion point:
+
+```python
+from flydsl.compiler.context import RAIIMLIRContextModule
+
+ctx = RAIIMLIRContextModule(allow_unregistered_dialects=True)
+# ctx.context  -- MLIR Context
+# ctx.module   -- MLIR Module
+# ctx.location -- Default Location
+```
+
+### 3.2 `MlirModule`
+
+Base class for structured kernel authoring. Subclass it, define `@kernel` and `@jit` methods:
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir
+
+class MyKernels(MlirModule):
+    GPU_MODULE_NAME = "my_kernels"
+
+    @kernel
+    def my_kernel(self, A: T.memref(1024, T.f32())):
+        tid = flir.thread_idx("x")
+        # ... kernel body ...
+
+# Instantiate to emit MLIR
+mod = MyKernels()
+print(mod.module)  # prints MLIR
+```
+
+Key class attributes:
+- `GPU_MODULE_NAME` -- name for the `gpu.module` container
+- `GPU_MODULE_TARGETS` -- optional target list (overridden by `flir.compile()`)
+- `ALLOW_UNREGISTERED_DIALECTS` -- default `True`
+
+Key decorators:
+- `@kernel` -- emits a `gpu.func` with `gpu.kernel` attribute, enables range-loop lowering
+- `@jit` -- emits a host-side `func.func` with `llvm.emit_c_interface`
+
+### 3.3 `ExecutionEngineExecutor`
+
+Wraps MLIR's `ExecutionEngine` for JIT execution:
+
+```python
+executor = compile(mod)
+# Dynamic attribute lookup → calls compiled function
+executor.my_kernel(tensor_a, tensor_b)
+```
+
+Features:
+- Automatically resolves `_mlir_ciface_*` symbols
+- Supports PyTorch tensors as arguments (auto-expands to memref descriptor)
+- Handles both flattened and packed calling conventions
+
+### 3.4 `Pipeline`
+
+Fluent pass-pipeline builder (see Section 2.3).
+
+### 3.5 `FileCache`
+
+On-disk compilation cache (inspired by Triton):
+
+- Cache key: SHA-256 of `(chip, pipeline, input_sha256, flydsl version, git commit, python version, soabi, platform)`
+- Storage: `$FLIR_CACHE_DIR` or `$XDG_CACHE_HOME/flydsl/<key>/` (default: `~/.cache/flydsl/<key>/`)
+- Atomic writes with file locking
+- Controlled by environment variables (see Section 4)
+
+---
+
+## 4. Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `COMPILE_ONLY` | `0` | If `1`, compile without creating an executor. Returns `None`. |
+| `FLIR_DUMP_IR` | `0` | If `1`, dump intermediate IR at each pipeline stage. |
+| `FLIR_DUMP_DIR` | `my_ir_dumps` | Directory for IR dumps when `FLIR_DUMP_IR=1`. |
+| `ARCH` | auto-detect | Override target GPU architecture (e.g., `gfx942`, `gfx950`). |
+| `FLIR_CHIP` | -- | Alternative to `ARCH` for target chip (checked by `get_rocm_arch()`). |
+| `FLIR_GPU_ARCH` | -- | Alternative to `ARCH` for target chip (checked by `get_rocm_arch()`). |
+| `FLIR_CACHE_DIR` | `~/.cache/flydsl` | Override compilation cache directory. |
+| `FLIR_NO_CACHE` | `0` | If `1`, disable compilation caching. |
+| `FLIR_CACHE_DISABLE` | `0` | Alternative to `FLIR_NO_CACHE`. |
+| `FLIR_REBUILD` | `0` | If `1`, force recompilation (ignore cache). |
+| `FLIR_CACHE_REBUILD` | `0` | Alternative to `FLIR_REBUILD`. |
+
+### Architecture Detection Priority
+
+`get_rocm_arch()` in `runtime/device.py` checks in order:
+1. `FLIR_CHIP` env var
+2. `FLIR_GPU_ARCH` env var
+3. `HSA_OVERRIDE_GFX_VERSION` env var (supports `9.4.2` → `gfx942` format)
+4. PyTorch `torch.cuda.get_device_properties().gcnArchName`
+5. Default: `gfx942`
+
+---
+
+## 5. Target Hardware
+
+| Architecture | GPU | LDS per CU | Notes |
+|---|---|---|---|
+| `gfx942` | MI300A / MI300X | 64 KB | CDNA 3, primary development target |
+| `gfx950` | MI350 | 160 KB | CDNA 4, larger LDS |
+| `gfx90a` | MI250X | 64 KB | CDNA 2 (verified platform) |
+
+---
+
+## 6. IR Dump Workflow
+
+Enable with `FLIR_DUMP_IR=1`:
+
+```bash
+FLIR_DUMP_IR=1 FLIR_DUMP_DIR=./dumps python test_my_kernel.py
+```
+
+Produces numbered `.mlir` files:
+```
+dumps/my_kernel/
+├── 00_target_overridden.mlir
+├── 03_flir_to_standard.mlir
+├── 04_trivial_dce.mlir
+├── 05_canonicalize.mlir
+├── 06_cse.mlir
+├── 07_gpu_kernel_outlining.mlir
+├── 08_convert_scf_to_cf.mlir
+├── 09_convert_gpu_to_rocdl.mlir
+├── 10_reconcile_unrealized_casts.mlir
+├── 11_rocdl_attach_target.mlir
+├── 12_gpu_to_llvm.mlir
+├── 13_reconcile_unrealized_casts.mlir
+├── 14_gpu_module_to_binary.mlir
+└── 15_final_isa.s                  # AMD ISA assembly (best-effort)
+```
+
+---
+
+## 7. Source Files
+
+| File | Description |
+|---|---|
+| `flydsl/src/flydsl/compiler/compiler.py` | `flir.compile()` entry point, pipeline construction, IR dump logic |
+| `flydsl/src/flydsl/compiler/pipeline.py` | `Pipeline` fluent API, `run_pipeline()`, `lower_flir_to_standard()` |
+| `flydsl/src/flydsl/compiler/executor.py` | `ExecutionEngineExecutor`, shared library resolution |
+| `flydsl/src/flydsl/compiler/context.py` | `RAIIMLIRContext`, `RAIIMLIRContextModule`, dialect registration |
+| `flydsl/src/flydsl/compiler/cache.py` | `FileCache`, `make_cache_key()`, cache env var handling |
+| `flydsl/src/flydsl/runtime/device.py` | `get_rocm_arch()` GPU detection |
+| `flydsl/src/flydsl/lang/ir/module.py` | `MlirModule`, `@kernel`, `@jit` decorators |
+| `flir/include/flir/FlirPasses.td` | Pass declarations (flir-to-standard, trivial-dce) |
+| `flir/lib/Transforms/FlirToStandard.cpp` | FLIR → standard lowering implementation |
+| `flir/lib/Transforms/FlirDCE.cpp` | Dead code elimination implementation |

--- a/docs/cutedsl_to_flydsl_porting_guide.md
+++ b/docs/cutedsl_to_flydsl_porting_guide.md
@@ -1,0 +1,568 @@
+# CuteDSL → FlyDSL Porting Guide
+
+> Mapping concepts, APIs, and patterns from NVIDIA CuteDSL (CUTLASS Python DSL) to AMD FlyDSL (FLIR Python DSL).
+
+## Quick Reference
+
+| CuteDSL (NVIDIA) | FlyDSL (AMD) |
+|---|---|
+| `import cutlass.cute as cute` | `from flydsl.dialects.ext import flir` |
+| `@cute.jit` | `@kernel` / `@jit` (from `flydsl.lang.ir.module`) |
+| `cutlass.Constexpr[int]` | Python int literal (static at IR level) |
+| `cute.Tensor` | `flir.TensorView` |
+| `cute.make_layout(shape, stride)` | `flir.make_layout(shape, stride)` |
+| `cute.tiled_divide(layout, tiler)` | `flir.tiled_divide(layout, tiler)` |
+| `cute.gemm(tiled_mma, a, b, c)` | `flir.rocm.mfma(a, b, c)` / MFMA intrinsic |
+| `cute.copy(atom, src, dst)` | `flir.copy(atom, src, dst)` |
+| CUDA / PTX output | HIP / ROCDL / HSACO output |
+| SM80 / SM90 / SM100 | GFX942 / GFX950 / GFX90a |
+
+---
+
+## 1. Overview
+
+Both CuteDSL and FlyDSL are Python DSLs for writing high-performance GPU kernels with explicit layout control. They share a common intellectual heritage from NVIDIA's CuTe layout algebra but target different hardware:
+
+| Aspect | CuteDSL | FlyDSL |
+|---|---|---|
+| **Organization** | Part of NVIDIA CUTLASS | Standalone project |
+| **Hardware** | NVIDIA GPUs (CUDA) | AMD GPUs (ROCm/HIP) |
+| **IR backend** | CUTLASS MLIR dialects → CUDA/PTX | FLIR MLIR dialect → ROCDL → HSACO |
+| **Layout algebra** | `cutlass.cute` module | `flir` MLIR dialect + Python API |
+| **Kernel model** | `@cute.jit` decorator | `MlirModule` class + `@kernel`/`@jit` |
+| **Memory model** | GMEM → SMEM → RMEM → TMEM | GMEM → LDS → VGPR |
+| **Compilation** | Python JIT → MLIR → CUDA binary | Python → MLIR → ROCDL → HSACO binary |
+| **Wave/Warp size** | 32 threads (warp) | 64 threads (wavefront) |
+
+---
+
+## 2. Layout System Mapping
+
+The layout algebra is nearly identical between CuteDSL and FlyDSL. Both implement the same mathematical foundation from CuTe.
+
+### 2.1 Core Types
+
+| CuteDSL | FlyDSL | Notes |
+|---|---|---|
+| `cute.make_shape(M, N)` | `flir.make_shape(M, N)` | Identical semantics |
+| `cute.make_stride(s0, s1)` | `flir.make_stride(s0, s1)` | Identical semantics |
+| `cute.make_layout(shape, stride)` | `flir.make_layout(shape, stride)` | Identical semantics |
+| `cute.make_coord(i, j)` | `flir.make_coord(i, j)` | Identical semantics |
+| Python int literal | Python int literal | Both: static at compile time |
+| `cutlass.Constexpr[int]` | Python int (always static) | FlyDSL ints are static in MLIR IR |
+
+**CuteDSL:**
+```python
+import cutlass.cute as cute
+
+shape = cute.make_shape(128, 64)
+stride = cute.make_stride(1, 128)    # Column-major
+layout = cute.make_layout(shape, stride)
+coord = cute.make_coord(3, 5)
+```
+
+**FlyDSL:**
+```python
+from flydsl.dialects.ext import flir
+
+shape = flir.make_shape(128, 64)
+stride = flir.make_stride(1, 128)    # Column-major
+layout = flir.make_layout(shape, stride)
+coord = flir.make_coord(3, 5)
+```
+
+### 2.2 Query Operations
+
+| CuteDSL | FlyDSL | Formula |
+|---|---|---|
+| `cute.size(layout)` | `flir.size(layout)` | Product of shape elements |
+| `cute.cosize(layout)` | `flir.cosize(layout)` | Max index + 1 |
+| `cute.rank(layout)` | `flir.rank(layout)` | Number of modes |
+| `cute.size(layout, mode=[i])` | `flir.get(flir.get_shape(layout), i)` | Size of mode i |
+
+### 2.3 Coordinate Mapping
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.crd2idx(coord, layout)` | `flir.crd2idx(coord, layout)` | Coord → linear index |
+| `cute.idx2crd(idx, layout)` | `flir.idx2crd(idx, layout)` | Linear index → coord |
+
+Both compute `index = dot(coord, stride)`.
+
+### 2.4 Layout Algebra Operations
+
+All layout algebra operations have identical names and semantics:
+
+| Operation | CuteDSL | FlyDSL |
+|---|---|---|
+| **Composition** | `cute.composition(A, B)` | `flir.composition(A, B)` |
+| **Complement** | `cute.complement(layout, cotarget)` | `flir.complement(layout, cotarget)` |
+| **Coalesce** | `cute.coalesce(layout)` | `flir.coalesce(layout)` |
+| **Logical Product** | `cute.logical_product(A, B)` | `flir.logical_product(A, B)` |
+| **Zipped Product** | `cute.zipped_product(A, B)` | `flir.zipped_product(A, B)` |
+| **Tiled Product** | `cute.tiled_product(A, B)` | `flir.tiled_product(A, B)` |
+| **Flat Product** | `cute.flat_product(A, B)` | `flir.flat_product(A, B)` |
+| **Raked Product** | `cute.raked_product(A, B)` | `flir.raked_product(A, B)` |
+| **Blocked Product** | `cute.blocked_product(A, B)` | `flir.blocked_product(A, B)` |
+| **Logical Divide** | `cute.logical_divide(A, tiler)` | `flir.logical_divide(A, tiler)` |
+| **Zipped Divide** | `cute.zipped_divide(A, tiler)` | `flir.zipped_divide(A, tiler)` |
+| **Tiled Divide** | `cute.tiled_divide(A, tiler)` | `flir.tiled_divide(A, tiler)` |
+| **Flat Divide** | `cute.flat_divide(A, tiler)` | `flir.flat_divide(A, tiler)` |
+| **Local Partition** | `cute.local_partition(layout, ...)` | `flir.local_partition(layout, ...)` |
+| **Local Tile** | `cute.local_tile(layout, ...)` | `flir.local_tile(layout, ...)` |
+
+---
+
+## 3. Kernel Definition
+
+### 3.1 CuteDSL Pattern
+
+CuteDSL uses `@cute.jit` decorator on methods of a kernel class:
+
+```python
+import cutlass.cute as cute
+import cutlass
+
+class MyKernel:
+    def __init__(self, acc_dtype, mma_tiler_mn, ...):
+        self.acc_dtype = acc_dtype
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        ...
+
+    @cute.jit
+    def __call__(
+        self,
+        A: cute.Tensor,
+        B: cute.Tensor,
+        C: cute.Tensor,
+        M: cutlass.Constexpr[int],
+    ):
+        # Kernel body
+        ...
+```
+
+### 3.2 FlyDSL Pattern
+
+FlyDSL uses `MlirModule` subclass with `@kernel` and `@jit` decorators:
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir, arith, gpu
+import _mlir.extras.types as T
+
+class MyKernel(MlirModule):
+    GPU_MODULE_NAME = "my_kernel"
+    GPU_MODULE_TARGETS = ['#rocdl.target<chip = "gfx942">']
+
+    @kernel
+    def my_kernel(self,
+                  A: T.memref(T.dynamic(), T.f16()),
+                  B: T.memref(T.dynamic(), T.f16()),
+                  C: T.memref(T.dynamic(), T.f16()),
+                  M: T.index()):
+        # Kernel body
+        ...
+
+    @jit
+    def __call__(self, A, B, C, M, stream_ptr: T.i64()):
+        # Host-side launch wrapper
+        ...
+```
+
+**Key differences:**
+| CuteDSL | FlyDSL |
+|---|---|
+| `@cute.jit` on any method | `@kernel` for GPU function, `@jit` for host function |
+| Class is a plain Python class | Class extends `MlirModule` |
+| Parameters typed with `cute.Tensor`, `cutlass.Constexpr[int]` | Parameters typed with `T.memref(...)`, `T.index()` |
+| Compilation via CUTLASS JIT pipeline | Compilation via `flir.compile()` |
+| No explicit `GPU_MODULE_NAME` | Must set `GPU_MODULE_NAME` class attribute |
+
+---
+
+## 4. Thread and Block Hierarchy
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.arch.thread_idx()` | `flir.thread_idx("x")` | Thread index within block |
+| `cute.arch.block_idx()` | `flir.block_idx("x")` | Block index |
+| `cute.arch.block_dim()` | `flir.block_dim("x")` | Block dimension |
+| `cute.arch.cluster_idx()` | *(not applicable)* | Cluster index (SM90+) |
+
+**CuteDSL:**
+```python
+tid = cute.arch.thread_idx()
+bid = cute.arch.block_idx()
+```
+
+**FlyDSL:**
+```python
+tid = flir.thread_idx("x")
+bid = flir.block_idx("x")
+```
+
+---
+
+## 5. Tensor Creation and Memory
+
+### 5.1 Tensor Construction
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.make_tensor(ptr, layout)` | `flir.make_tensor(memref, shape, strides, ...)` | Create a tensor view |
+| `cute.make_rmem_tensor(shape, dtype)` | `flir.make_fragment_like(template)` | Register fragment |
+| `cute.Tensor` (SSA-based) | `flir.TensorView` (Python wrapper) | Tensor abstraction |
+
+**CuteDSL:**
+```python
+# Global memory tensor
+gmem_A = cute.make_tensor(global_A_ptr, cute.make_layout((M, K), (1, M)))
+
+# Register fragment
+rmem_frag = cute.make_rmem_tensor((16, 16), cute.float32)
+```
+
+**FlyDSL:**
+```python
+# Global memory tensor view
+gmem_A = flir.TensorView(
+    arg_a,                  # memref argument
+    (tile_m, tile_k),       # shape
+    strides=(1, M),         # strides
+    base_indices=(base_m,), # base offset
+    element_type=T.f16(),
+)
+
+# Register fragment
+rmem_frag = flir.make_fragment_like(template_tensor)
+```
+
+### 5.2 Memory Hierarchy
+
+| CuteDSL (NVIDIA) | FlyDSL (AMD) | Notes |
+|---|---|---|
+| Global Memory (GMEM) | Global Memory (GMEM) | Same concept |
+| Shared Memory (SMEM, 48-228 KB) | LDS (Local Data Share, 64-160 KB) | Same purpose, different name |
+| Register File (RMEM) | VGPR (Vector General Purpose Registers) | Same purpose |
+| Tensor Memory (TMEM, Blackwell) | *(not applicable)* | Blackwell-specific |
+| L2 Cache | L2 Cache | Similar |
+
+**Shared memory allocation:**
+
+**CuteDSL:**
+```python
+# Shared memory is allocated within the kernel
+smem_layout = cute.make_layout((128, 64), (1, 128))
+smem_tensor = cute.make_tensor(smem_ptr, smem_layout)
+```
+
+**FlyDSL:**
+```python
+from flydsl.utils import SmemAllocator
+
+allocator = SmemAllocator(ctx, arch="gfx942")
+lds_gen = allocator.allocate_array(T.f16(), num_elems=128*64)
+allocator.finalize()  # Inside gpu.module body
+
+# Inside kernel:
+base = allocator.get_base()
+lds_ptr = lds_gen(base)  # SmemPtr for typed access
+```
+
+### 5.3 Swizzling (Bank Conflict Avoidance)
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.Swizzle(M, B, S)` | `flir.swizzle_xor16(row, col, k_blocks)` | LDS bank conflict avoidance |
+
+CuteDSL uses parameterized `Swizzle<M,B,S>` templates. FlyDSL uses XOR16 byte-level swizzle at 16-byte granularity.
+
+**FlyDSL:**
+```python
+col_swizzled = flir.swizzle_xor16(row, col_bytes, k_blocks16)
+```
+
+---
+
+## 6. Data Movement (Copy Operations)
+
+### 6.1 Copy Atoms and Tiled Copies
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.Copy[cute.SM80_TMA[...]]()` | `flir.make_copy_atom(dtype, vector_size)` | Copy descriptor |
+| `cute.copy(atom, src, dst)` | `flir.copy(atom, src, dst)` | Execute copy |
+| *(implicit in tiled copy)* | `flir.make_tiled_copy_tv(atom, thr, val)` | Distributed copy |
+| *(via copy API)* | `tiled.get_slice(tid)` → `.partition_S(src)` / `.partition_D(dst)` | Thread-level slicing |
+
+**CuteDSL:**
+```python
+# TMA copy (Hopper/Blackwell)
+tma_copy = cute.TMA(...)
+cute.copy(tma_copy, gmem_src, smem_dst)
+
+# CpAsync copy (Ampere)
+cute.cpasync(gmem_src, smem_dst, size)
+```
+
+**FlyDSL:**
+```python
+# Create copy atom
+atom = flir.make_copy_atom(T.f16(), vector_size=8)
+
+# Create tiled copy (distributed across threads)
+thr_layout = flir.make_ordered_layout(256, 8)  # 256 threads, 8 elements each
+val_layout = flir.make_layout(flir.make_shape(1, 8), flir.make_stride(0, 1))
+tiled_copy = flir.make_tiled_copy_tv(atom, thr_layout, val_layout)
+
+# Get thread slice
+thr_copy = tiled_copy.get_slice(tid)
+src_partition = thr_copy.partition_S(src_tensor)
+dst_partition = thr_copy.partition_D(dst_tensor)
+
+# Execute copy
+flir.copy(tiled_copy, src_tensor, dst_tensor)
+```
+
+### 6.2 Buffer Loads (AMD-specific)
+
+FlyDSL provides AMD-specific buffer load intrinsics not present in CuteDSL:
+
+```python
+from flydsl.dialects.ext import buffer_ops
+
+# Buffer resource for global memory (AMD buffer load dwordx4)
+rsrc = buffer_ops.create_buffer_resource(arg_a, num_records)
+
+# Buffer load 16 bytes
+from kernels.mfma_preshuffle_pipeline import buffer_copy_gmem16_dwordx4
+vec = buffer_copy_gmem16_dwordx4(flir, arg=arg_a, elem_type=T.i8(),
+                                  idx_i32=offset, atom_g2r16=atom, rsrc=rsrc)
+```
+
+---
+
+## 7. Compute Operations (MMA / MFMA)
+
+### 7.1 Matrix Multiply
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.TiledMMA(...)` | MFMA intrinsics (see below) | Tiled matrix multiply |
+| `cute.gemm(tiled_mma, a, b, c)` | Manual MFMA loop | Matrix multiply-accumulate |
+| SM80 Tensor Cores | MFMA (Matrix Fused Multiply-Add) | Hardware MMA unit |
+| Warp-level (32 threads) | Wavefront-level (64 threads) | Cooperative MMA |
+
+**CuteDSL (SM90/SM100):**
+```python
+tiled_mma = sm100_utils.make_trivial_tiled_mma(
+    a_dtype=cute.float16,
+    a_major_mode=cute.LayoutRight,
+    b_major_mode=cute.LayoutRight,
+    acc_dtype=cute.float32,
+    cta_group=tcgen05.CtaGroup.ONE,
+    mma_shape=(128, 64),
+)
+cute.gemm(tiled_mma, a_frag, b_frag, c_accumulator)
+```
+
+**FlyDSL (GFX942/GFX950):**
+```python
+from flydsl.dialects.ext import rocdl
+
+# Direct MFMA intrinsic (16x16xK)
+# FP8: mfma_f32_16x16x32_fp8_fp8 (K=32)
+# INT8: mfma_i32_16x16x32_i8 (K=32)
+# FP16: mfma_f32_16x16x16f16 (K=16)
+c_acc = rocdl.mfma_f32_16x16x32_fp8_fp8(a_pack, b_pack, c_acc)
+
+# K64-byte micro-step pattern (2x K32 per step)
+for ku in range(tile_k_bytes // 64):
+    a_val = lds_load_pack_k32(...)   # Load A from LDS
+    b_val = load_b_pack_k32(...)     # Load B from GMEM
+    c_acc = rocdl.mfma_f32_16x16x32_fp8_fp8(a_val, b_val, c_acc)
+    # second half
+    a_val2 = lds_load_pack_k32(...)
+    b_val2 = load_b_pack_k32(...)
+    c_acc = rocdl.mfma_f32_16x16x32_fp8_fp8(a_val2, b_val2, c_acc)
+```
+
+### 7.2 MMA Instruction Mapping
+
+| CuteDSL (NVIDIA) | FlyDSL (AMD) | Sizes |
+|---|---|---|
+| `mma.sync.m16n8k16.f16` (SM80) | `mfma_f32_16x16x16f16` | M16 N16 K16 |
+| `mma.sync.m16n8k32.s8` (SM80) | `mfma_i32_16x16x32_i8` | M16 N16 K32 |
+| `tcgen05.mma` (SM100) | `mfma_f32_16x16x32_fp8_fp8` | M16 N16 K32 |
+| *(N/A)* | `mfma_scale_x128` (GFX950) | MXFP4 scaled MMA |
+
+---
+
+## 8. Synchronization
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.arch.syncthreads()` | `gpu.barrier()` | Block-level barrier |
+| `cute.arch.fence_view_async_shared()` | `gpu.barrier()` | Shared memory fence |
+| `pipeline.NamedBarrier(...)` | *(manual barrier)* | Named barriers |
+| `cute.arch.cluster_sync()` | *(not applicable)* | Cluster sync (SM90+) |
+
+**CuteDSL:**
+```python
+cute.arch.syncthreads()
+```
+
+**FlyDSL:**
+```python
+from flydsl.dialects.ext import gpu
+gpu.barrier()
+```
+
+---
+
+## 9. Compilation and Execution
+
+### 9.1 Compilation Pipeline
+
+**CuteDSL:**
+```python
+# JIT compilation is implicit via @cute.jit
+kernel = MyKernel(acc_dtype=cutlass.Float32, ...)
+kernel(A_tensor, B_tensor, C_tensor, M=M)  # First call triggers compilation
+```
+
+**FlyDSL:**
+```python
+import flydsl
+
+# Option 1: Using compile() (preferred for production)
+mod = MyKernel()
+executor = flydsl.compile(mod)
+executor(A_torch, B_torch, C_torch, M)
+
+# Option 2: Using compile_to_hsaco() (for tests)
+from tests.utils import compile_to_hsaco
+hsaco_bytes = compile_to_hsaco(mod)
+```
+
+### 9.2 Environment Variables
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| *(CUDA_VISIBLE_DEVICES)* | `FLIR_CHIP` / `FLIR_GPU_ARCH` | Target architecture |
+| *(N/A)* | `FLIR_DUMP_IR=1` | Dump intermediate MLIR IR |
+| *(N/A)* | `FLIR_DUMP_DIR=/path` | IR dump location |
+| *(N/A)* | `COMPILE_ONLY=1` | Skip execution, compile only |
+| *(N/A)* | `FLIR_NO_CACHE=1` | Disable compilation cache |
+| *(N/A)* | `FLIR_TIME_COMPILE=1` | Print compilation timing |
+
+---
+
+## 10. Complete Porting Example: Vector Addition
+
+### CuteDSL Version
+
+```python
+import cutlass.cute as cute
+import cutlass
+
+class VecAddKernel:
+    @cute.jit
+    def __call__(self, A: cute.Tensor, B: cute.Tensor, C: cute.Tensor,
+                 N: cutlass.Constexpr[int]):
+        tid = cute.arch.thread_idx()
+        bid = cute.arch.block_idx()
+        idx = bid * 256 + tid
+        if idx < N:
+            C[idx] = A[idx] + B[idx]
+```
+
+### FlyDSL Version
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir, arith, gpu
+import _mlir.extras.types as T
+
+class VecAddKernel(MlirModule):
+    GPU_MODULE_NAME = "vec_add"
+
+    @kernel
+    def vec_add(self,
+                A: T.memref(T.dynamic(), T.f32()),
+                B: T.memref(T.dynamic(), T.f32()),
+                C: T.memref(T.dynamic(), T.f32()),
+                N: T.index()):
+        tid = flir.thread_idx("x")
+        bid = flir.block_idx("x")
+        block_size = arith.constant(256, index=True)
+        idx = bid * block_size + tid
+
+        # Load (via memref dialect, accessed through flir)
+        a_val = flir.memref.load(A, [idx])
+        b_val = flir.memref.load(B, [idx])
+
+        # Compute
+        c_val = arith.addf(a_val, b_val)
+
+        # Store
+        flir.memref.store(c_val, C, [idx])
+```
+
+---
+
+## 11. GEMM Porting Checklist
+
+When porting a CuteDSL GEMM to FlyDSL:
+
+1. **Replace `@cute.jit`** with `MlirModule` + `@kernel` / `@jit`
+2. **Replace `cute.Tensor`** parameters with `T.memref(...)` types
+3. **Replace `cute.make_layout()`** with `flir.make_layout()` (identical API)
+4. **Replace NVIDIA tensor cores** with AMD MFMA intrinsics:
+   - `mfma_f32_16x16x32_fp8_fp8` for FP8
+   - `mfma_i32_16x16x32_i8` for INT8
+   - `mfma_f32_16x16x16f16` for FP16
+5. **Replace SMEM allocation** with `SmemAllocator`
+6. **Replace `cute.Swizzle`** with `flir.swizzle_xor16()`
+7. **Replace TMA/CpAsync** with `buffer_ops` (AMD buffer loads)
+8. **Adjust warp size**: 32 → 64 (AMD wavefront)
+9. **Adjust shared memory limits**: Check `SMEM_CAPACITY_MAP` (gfx942=64KB, gfx950=160KB)
+10. **Replace `cute.arch.syncthreads()`** with `gpu.barrier()`
+11. **Use `flydsl.compile()`** instead of CuteDSL JIT compilation
+
+---
+
+## 12. Key Differences Summary
+
+| Aspect | CuteDSL | FlyDSL |
+|---|---|---|
+| **Language** | Python + `@cute.jit` | Python + MLIR emission |
+| **Hardware** | NVIDIA CUDA GPUs | AMD ROCm GPUs |
+| **Warp/Wave size** | 32 (warp) | 64 (wavefront) |
+| **Shared memory** | SMEM (48-228 KB) | LDS (64-160 KB) |
+| **MMA unit** | Tensor Core (HMMA/GMMA/TCGEN05) | MFMA |
+| **Global loads** | `ld.global` / TMA / CpAsync | `buffer_load_dwordx4` |
+| **Swizzle** | `Swizzle<M,B,S>` | `swizzle_xor16` |
+| **Compilation** | Python JIT → CUDA binary | Python → MLIR → HSACO |
+| **Caching** | *(managed by CUTLASS)* | `FileCache` (SHA-256 keyed) |
+| **Layout algebra** | Identical semantics | Identical semantics |
+| **IR dump** | *(via CUTLASS debug flags)* | `FLIR_DUMP_IR=1` |
+
+---
+
+## 13. Source Files
+
+### CuteDSL (reference)
+- CUTLASS GitHub: `python/cutlass/cute/` — Core CuteDSL module
+- CUTLASS GitHub: `examples/blackwell/` — Example kernels (dense GEMM, grouped GEMM, flash attention)
+- PyTorch Inductor: `torch/_inductor/codegen/cutedsl/` — CuteDSL integration in PyTorch
+- PyCute: `torch/distributed/_pycute/layout.py` — Pure-Python layout algebra reference
+
+### FlyDSL
+- `flydsl/src/flydsl/dialects/ext/flir.py` — Layout algebra Python API
+- `flydsl/src/flydsl/lang/ir/module.py` — MlirModule, @kernel, @jit
+- `flydsl/src/flydsl/compiler/compiler.py` — `flir.compile()` pipeline
+- `flydsl/src/flydsl/utils/smem_allocator.py` — SmemAllocator
+- `flydsl/src/flydsl/dialects/ext/rocm.py` — ROCm dialect helpers
+- `kernels/preshuffle_gemm.py` — GEMM implementation example
+- `tests/kernels/test_vec_add.py` — VecAdd example with full layout algebra

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -1,0 +1,509 @@
+# Kernel Authoring Guide
+
+> Writing GPU kernels with FlyDSL: MlirModule, thread hierarchy, TensorView, tiled copies, MFMA, shared memory, and synchronization.
+
+## Quick Reference
+
+| Concept | API | Description |
+|---|---|---|
+| **Module** | `class MyKernel(MlirModule)` | Base class for kernel modules |
+| **Kernel** | `@kernel` decorator | Emit `gpu.func` with `gpu.kernel` attribute |
+| **Host func** | `@jit` decorator | Emit host-side `func.func` |
+| **Thread ID** | `flir.thread_idx("x")` | Get thread index in workgroup |
+| **Block ID** | `flir.block_idx("x")` | Get block/workgroup index |
+| **Block dim** | `flir.block_dim("x")` | Get block dimension size |
+| **Tensor** | `flir.make_tensor(ptr, shape, strides)` | Create a TensorView |
+| **Fragment** | `flir.make_fragment_like(template)` | Register memory buffer |
+| **Copy atom** | `flir.make_copy_atom(dtype, vec_size)` | Copy descriptor |
+| **Tiled copy** | `flir.make_tiled_copy_tv(atom, thr, val)` | Distributed copy |
+| **Copy** | `flir.copy(tiled, src, dst)` | Execute data movement |
+| **LDS** | `SmemAllocator` | Shared memory management |
+| **Barrier** | `gpu.barrier()` | Workgroup synchronization |
+| **Compile** | `compile(module)` | Full pipeline → executor |
+
+---
+
+## 1. Module Structure
+
+### 1.1 Using `MlirModule` (Structured Pattern)
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir, arith, gpu
+import _mlir.extras.types as T
+
+class VecAddKernel(MlirModule):
+    GPU_MODULE_NAME = "vec_add"
+
+    @kernel
+    def vecAdd(self, A: T.memref(1024, T.f32()),
+                     B: T.memref(1024, T.f32()),
+                     C: T.memref(1024, T.f32())):
+        tid = flir.thread_idx("x")
+        bid = flir.block_idx("x")
+        # ... kernel body ...
+
+# Instantiate to emit MLIR
+mod = VecAddKernel()
+print(mod.module)  # view MLIR IR
+```
+
+### 1.2 Using `RAIIMLIRContextModule` (Standalone Pattern)
+
+```python
+from flydsl.compiler.context import RAIIMLIRContextModule
+from flydsl.dialects.ext import gpu, flir
+import _mlir.extras.types as T
+
+ctx = RAIIMLIRContextModule(allow_unregistered_dialects=True)
+gpu.set_container_module(ctx.module)
+
+@gpu.module("my_kernels", ["#rocdl.target<abi = \"500\">"])
+def mod():
+    pass
+
+@flir.kernel
+def my_kernel(A: T.memref(1024, T.f32())):
+    tid = flir.thread_idx("x")
+    # ... kernel body ...
+```
+
+### 1.3 `MlirModule` Class Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| `GPU_MODULE_NAME` | `"kernels"` | Name of the `gpu.module` container |
+| `GPU_MODULE_TARGETS` | `None` | Target list (overridden by `flir.compile()`) |
+| `ALLOW_UNREGISTERED_DIALECTS` | `True` | Allow unknown dialects in context |
+
+### 1.4 `init_gpu_module()` Hook
+
+Override this method in your `MlirModule` subclass to insert ops at the beginning of the `gpu.module` body (e.g., `memref.global` for shared memory):
+
+```python
+class MyKernel(MlirModule):
+    GPU_MODULE_NAME = "my_kernel"
+
+    def init_gpu_module(self):
+        # Called before any @kernel methods
+        self.smem.finalize()  # emit memref.global for LDS
+```
+
+---
+
+## 2. Thread / Block Hierarchy
+
+```python
+# Thread index within workgroup (0 to blockDim-1)
+tid_x = flir.thread_idx("x")  # returns index-typed Value
+tid_y = flir.thread_idx("y")
+tid_z = flir.thread_idx("z")
+
+# Block (workgroup) index within grid
+bid_x = flir.block_idx("x")
+bid_y = flir.block_idx("y")
+
+# Block dimensions
+bdim_x = flir.block_dim("x")
+
+# Linear thread index (common pattern)
+tid_linear = (flir.thread_idx("y") * flir.block_dim("x")
+              + flir.thread_idx("x")).value
+```
+
+---
+
+## 3. TensorView
+
+`TensorView` is the Python-side representation of a multi-dimensional memory region:
+
+```python
+# Create from memref pointer with shape and strides
+tensor_A = flir.make_tensor(A, shape=(M, N), strides=(N, 1))
+
+# Create 1D view
+tensor_flat = flir.make_tensor(ptr, shape=(N,), strides=(1,))
+```
+
+Key attributes:
+- `shape` -- tuple of dimension extents
+- `strides` -- memory strides per dimension
+- `base_indices` -- base offsets into the backing memref
+- `element_type` -- MLIR element type
+- `memref` -- backing MLIR memref value
+
+You can also construct a `TensorView` directly:
+
+```python
+view = flir.TensorView(
+    memref_value,
+    shape=(M, N),
+    strides=(N, 1),
+    base_indices=(offset_m, offset_n),
+    element_type=T.f16(),
+)
+```
+
+---
+
+## 4. Tiled Copies
+
+Tiled copies distribute data movement across threads in a workgroup.
+
+### 4.1 Copy Atom
+
+A `CopyAtom` describes a single thread's copy operation:
+
+```python
+# Copy atom: element type, vector width, coalesced flag
+copy_atom = flir.make_copy_atom(T.f32(), vector_size=8)
+copy_atom = flir.make_copy_atom(T.f16(), vector_size=16, is_coalesced=True)
+```
+
+### 4.2 Tiled Copy
+
+A `TiledCopy` distributes a copy atom across threads using thread and value layouts:
+
+```python
+THREADS = 256
+TILE = 8
+VEC = 4
+
+# Thread layout: how threads are arranged
+thr_layout = flir.make_ordered_layout((THREADS,), order=(0,))
+
+# Value layout: how many elements each thread handles
+val_layout = flir.make_ordered_layout((TILE,), order=(0,))
+
+# Create tiled copy
+tiled = flir.make_tiled_copy_tv(
+    copy_atom, thr_layout, val_layout,
+    thr_shape=(THREADS,), val_shape=(TILE,),
+)
+```
+
+### 4.3 Thread Slicing and Partitioning
+
+```python
+# Get this thread's slice of the copy
+thr_copy = tiled.get_slice(tid_linear)
+
+# Partition source and destination tensors for this thread
+thr_src = thr_copy.partition_S(src_tensor)
+thr_dst = thr_copy.partition_D(dst_tensor)
+```
+
+### 4.4 Copy Execution
+
+```python
+# Register fragment (destination buffer)
+frag = flir.make_fragment_like(thr_src, T.f32())
+
+# Execute copy: src → frag
+flir.copy(tiled, thr_src, frag)
+
+# Copy with predication (bounds checking)
+flir.copy(tiled, thr_src, frag, pred=mask)
+
+# Copy with LDS swizzle
+flir.copy(atom, src, dst,
+    dst_swizzle_xor16_kblocks=k_blocks,
+    dst_swizzle_xor16_dims=(0, 1))
+
+# Copy returning vector (for buffer loads)
+vec = flir.copy(atom, src, None,
+    return_vector=True,
+    src_buffer_resource=rsrc,
+    alignment=16)
+```
+
+---
+
+## 5. Register Fragments
+
+Fragments represent per-thread register storage:
+
+```python
+# Create fragment matching a TensorView's shape
+frag = flir.make_fragment_like(tensor_view, T.f32())
+
+# Create fragment matching a TiledCopy
+frag = flir.make_fragment_like(tiled_copy)
+
+# Create explicit register tensor
+rmem = flir.make_rmem_tensor((16, 16), T.f32())
+
+# Create identity/coordinate tensor
+identity = flir.make_identity_tensor((M, N))
+```
+
+---
+
+## 6. MFMA Operations
+
+Matrix Fused Multiply-Add instructions for AMD GPUs:
+
+### MLIR ROCm Dialect
+
+```mlir
+// Single MFMA instruction
+%d = flir.rocm.mfma %a, %b, %c {
+    shape = [32, 32, 8], arch = "gfx942"
+} : (!flir.tensor<f16, ...>, !flir.tensor<f16, ...>,
+     !flir.tensor<f32, ...>) -> !flir.tensor<f32, ...>
+
+// Tiled MFMA (multi-wavefront)
+%d = flir.rocm.tiled_mfma %a, %b, %c {
+    atom = #flir_rocm.mfma_atom<[32, 32, 8], f16, f16, f32, gfx942>,
+    tile_shape = [128, 128, 32]
+} : (...)
+```
+
+### Supported MFMA Shapes (GFX942)
+
+| Instruction | M | N | K | A Type | D Type |
+|---|---|---|---|---|---|
+| `mfma_f32_32x32x8_f16` | 32 | 32 | 8 | FP16 | FP32 |
+| `mfma_f32_16x16x16_f16` | 16 | 16 | 16 | FP16 | FP32 |
+| `mfma_f32_32x32x16_bf16` | 32 | 32 | 16 | BF16 | FP32 |
+| `mfma_f64_16x16x4_f64` | 16 | 16 | 4 | FP64 | FP64 |
+| `mfma_f32_16x16x32_f8` | 16 | 16 | 32 | FP8 | FP32 |
+| `mfma_i32_16x16x32_i8` | 16 | 16 | 32 | INT8 | INT32 |
+
+### In Python Kernel Code
+
+MFMA is typically used through the `rocdl` intrinsics after lowering, but the FLIR ROCm ops provide a structured interface during IR construction. See the GEMM kernels in `kernels/preshuffle_gemm.py` for complete examples.
+
+---
+
+## 7. Shared Memory (LDS)
+
+### 7.1 `SmemAllocator`
+
+```python
+from flydsl.utils.smem_allocator import SmemAllocator
+import _mlir.extras.types as T
+
+class MyGemmKernel(MlirModule):
+    GPU_MODULE_NAME = "gemm"
+
+    def __init__(self):
+        self.smem = SmemAllocator(None, arch="gfx942")
+        # Reserve LDS space before emitting kernels
+        self.lds_a = self.smem.allocate_array(T.f16(), 8192)
+        self.lds_b = self.smem.allocate_array(T.f16(), 8192)
+        super().__init__()
+
+    def init_gpu_module(self):
+        # Emit memref.global for the LDS buffer
+        self.smem.finalize()
+
+    @kernel
+    def gemm_kernel(self, ...):
+        # Get LDS base pointer inside kernel
+        lds_base = self.smem.get_base()
+        # Get typed views
+        lds_a_ptr = self.lds_a(lds_base)  # SmemPtr
+        lds_b_ptr = self.lds_b(lds_base)  # SmemPtr
+        # Load/store through SmemPtr
+        val = lds_a_ptr.load([idx])
+        lds_b_ptr.store(val, [idx])
+```
+
+### 7.2 `SmemAllocator` API
+
+| Method | Description |
+|---|---|
+| `allocate(size_bytes)` | Allocate raw bytes |
+| `allocate(mlir_type)` | Allocate one scalar of given type |
+| `allocate_array(dtype, num_elems)` | Allocate contiguous array |
+| `allocate_tensor(layout, element_type, swizzle=None)` | Allocate tensor with layout |
+| `finalize()` | Emit `memref.global` (call in `init_gpu_module`) |
+| `get_base()` | Get base pointer (call inside kernel) |
+
+### 7.3 LDS Capacity
+
+| Architecture | LDS per CU |
+|---|---|
+| `gfx942` (MI300X) | 64 KB |
+| `gfx950` (MI350) | 160 KB |
+
+The allocator checks capacity and raises `RuntimeError` on overflow.
+
+### 7.4 `SmemPtr`
+
+Returned by allocator generators, provides typed access to LDS regions:
+
+```python
+ptr = allocator_gen(lds_base)  # SmemPtr
+memref_view = ptr.get()        # ir.Value (memref view)
+val = ptr.load([idx])          # Load from LDS
+ptr.store(val, [idx])          # Store to LDS
+```
+
+---
+
+## 8. Synchronization
+
+```python
+from flydsl.dialects.ext import gpu
+
+# Workgroup barrier (s_barrier)
+gpu.barrier()
+```
+
+```mlir
+// MLIR
+gpu.barrier
+
+// ROCm dialect
+flir.rocm.barrier              // workgroup barrier
+flir.rocm.wavefront_barrier    // wavefront-level barrier
+```
+
+---
+
+## 9. Complete Example: VecAdd
+
+From `tests/kernels/test_vec_add.py`:
+
+```python
+from flydsl.compiler.context import RAIIMLIRContextModule
+from flydsl.compiler.compiler import compile
+from flydsl.dialects.ext import gpu, flir
+import _mlir.extras.types as T
+
+N = 20480000
+THREADS = 256
+TILE = 8
+VEC = 4
+
+# Set up MLIR context
+ctx = RAIIMLIRContextModule(allow_unregistered_dialects=True)
+gpu.set_container_module(ctx.module)
+
+@gpu.module("vec_kernels", ["#rocdl.target<abi = \"500\">"])
+def mod():
+    pass
+
+@flir.kernel
+def vecAdd(A: T.memref(N, T.f32()),
+           B: T.memref(N, T.f32()),
+           C: T.memref(N, T.f32())):
+    # Linear thread index
+    tid_linear = (flir.thread_idx("y") * flir.block_dim("x")
+                  + flir.thread_idx("x")).value
+
+    # Thread and value layouts
+    thr_layout = flir.make_ordered_layout((THREADS,), order=(0,))
+    val_layout = flir.make_ordered_layout((TILE,), order=(0,))
+
+    # Copy atom: f32, 4-wide vector loads
+    copy_atom = flir.make_copy_atom(T.f32(), vector_size=VEC)
+
+    # Tiled copy across all threads
+    tiled = flir.make_tiled_copy_tv(
+        copy_atom, thr_layout, val_layout,
+        thr_shape=(THREADS,), val_shape=(TILE,),
+    )
+
+    # Create tensors and partition into tiles
+    tensor_A = flir.make_tensor(A, shape=(N,), strides=(1,))
+    tiles_A = flir.zipped_divide(tensor_A, (THREADS * TILE,))
+    blkA = tiles_A[(flir.block_idx("x"),)]
+
+    # Get this thread's portion
+    thrA = tiled.get_slice(tid_linear).partition_S(blkA)
+    frgA = flir.make_fragment_like(thrA, T.f32())
+    flir.copy(tiled, thrA, frgA)
+
+    # ... repeat for B, add, store to C ...
+
+# Compile
+executor = compile(ctx.module)
+```
+
+---
+
+## 10. Kernel Launching
+
+After compilation, launch kernels through the executor:
+
+```python
+import torch
+
+# Create device tensors
+A = torch.randn(N, device="cuda", dtype=torch.float32)
+B = torch.randn(N, device="cuda", dtype=torch.float32)
+C = torch.empty(N, device="cuda", dtype=torch.float32)
+
+# Launch
+grid = (N // (THREADS * TILE), 1, 1)
+block = (THREADS, 1, 1)
+
+# For MlirModule-based kernels:
+executor = compile(mod)
+executor.vecAdd(A, B, C)
+
+# For GPUFunc-based kernels:
+vecAdd(A, B, C, grid_size=grid, block_size=block)
+```
+
+---
+
+## 11. Decision Tree
+
+```
+Writing a new kernel?
+
+├── Simple element-wise?
+│   ├── Use @flir.kernel with TensorView + copy
+│   └── See tests/kernels/test_vec_add.py
+│
+├── Reduction (norm, softmax)?
+│   ├── Use warp_reduce / block_reduce from kernels/reduce.py
+│   └── See kernels/layernorm_kernel.py, kernels/softmax_kernel.py
+│
+├── Matrix multiply (GEMM)?
+│   ├── Use MlirModule + SmemAllocator + MFMA
+│   ├── B-preshuffle layout from mfma_preshuffle_pipeline.py
+│   └── See kernels/preshuffle_gemm.py
+│
+├── Need shared memory?
+│   ├── Use SmemAllocator in MlirModule.__init__
+│   ├── Call finalize() in init_gpu_module()
+│   └── Call get_base() inside @kernel
+│
+└── Need custom pipeline?
+    ├── Use Pipeline fluent API
+    └── Or use flir.compile() with defaults
+```
+
+---
+
+## 12. Source Files
+
+| File | Description |
+|---|---|
+| `flydsl/src/flydsl/lang/ir/module.py` | `MlirModule`, `@kernel`, `@jit` decorators |
+| `flydsl/src/flydsl/dialects/ext/flir.py` | Layout API, TensorView, CopyAtom, TiledCopy, `copy()` |
+| `flydsl/src/flydsl/dialects/ext/gpu.py` | GPU dialect: `barrier()`, `LaunchFuncOp`, `GPUFuncOp` |
+| `flydsl/src/flydsl/dialects/ext/rocm.py` | ROCm helpers: MfmaOp, Copy ops |
+| `flydsl/src/flydsl/utils/smem_allocator.py` | `SmemAllocator`, `SmemPtr`, LDS capacity checks |
+| `flydsl/src/flydsl/compiler/compiler.py` | `compile()` entry point |
+| `flydsl/src/flydsl/compiler/context.py` | `RAIIMLIRContextModule` |
+| `flir/include/flir/FlirRocmOps.td` | ROCm dialect ops (MFMA, LDS, copy, barriers) |
+| `kernels/reduce.py` | Warp/block reduction primitives |
+| `tests/kernels/test_vec_add.py` | VecAdd example kernel |
+
+## 13. Test Files
+
+| File | Description |
+|---|---|
+| `tests/kernels/test_vec_add.py` | Vector add kernel test |
+| `tests/kernels/test_softmax.py` | Softmax kernel test |
+| `tests/kernels/test_layernorm.py` | LayerNorm kernel test |
+| `tests/kernels/test_preshuffle_gemm.py` | Preshuffle GEMM test |
+| `tests/kernels/test_eltwise_add.py` | Element-wise add test |
+| `tests/kernels/test_gpu_simple.py` | Simple GPU kernel tests |
+| `tests/kernels/test_shared_working.py` | Shared memory tests |

--- a/docs/layout_system_guide.md
+++ b/docs/layout_system_guide.md
@@ -1,0 +1,433 @@
+# FLIR Layout Algebra Guide
+
+> Core types, construction, coordinate mapping, algebra operations, and swizzling in the FLIR layout system.
+
+## Quick Reference
+
+| Operation | Python API | MLIR Op | Description |
+|---|---|---|---|
+| **Construction** | `flir.make_shape(8, 16)` | `flir.make_shape` | Create shape |
+| | `flir.make_stride(1, 8)` | `flir.make_stride` | Create stride |
+| | `flir.make_layout(shape, stride)` | `flir.make_layout` | Create layout from (shape, stride) |
+| | `flir.make_coord(i, j)` | `flir.make_coord` | Create coordinate |
+| | `flir.make_ordered_layout((8, 16), order=(1, 0))` | -- | Create layout with dimension ordering |
+| **Mapping** | `flir.crd2idx(coord, layout)` | `flir.crd2idx` | Coordinate → linear index |
+| | `flir.idx2crd(idx, layout)` | `flir.idx2crd` | Linear index → coordinate |
+| **Query** | `flir.size(layout)` | `flir.size` | Total element count |
+| | `flir.cosize(layout)` | `flir.cosize` | Codomain span |
+| | `flir.rank(layout)` | `flir.rank` | Number of dimensions |
+| | `flir.get(shape, idx)` | `flir.get` | Extract element at index |
+| **Algebra** | `flir.composition(A, B)` | `flir.composition` | Compose: A ∘ B |
+| | `flir.complement(tiler, size)` | `flir.complement` | Complement of tiler |
+| | `flir.coalesce(layout)` | `flir.coalesce` | Simplify layout |
+| **Products** | `flir.logical_product(A, B)` | `flir.logical_product` | Basic product |
+| | `flir.zipped_product(A, B)` | `flir.zipped_product` | Zipped product |
+| | `flir.tiled_product(A, B)` | `flir.tiled_product` | Tiled product |
+| | `flir.flat_product(A, B)` | `flir.flat_product` | Flat product |
+| | `flir.raked_product(A, B)` | `flir.raked_product` | Raked product |
+| | `flir.blocked_product(A, B)` | `flir.blocked_product` | Blocked product |
+| **Divides** | `flir.logical_divide(A, B)` | `flir.logical_divide` | Basic divide |
+| | `flir.zipped_divide(A, B)` | `flir.zipped_divide` | Zipped divide |
+| | `flir.tiled_divide(A, B)` | `flir.tiled_divide` | Tiled divide |
+| | `flir.flat_divide(A, B)` | `flir.flat_divide` | Flat divide |
+| **Partition** | `flir.local_partition(layout, tile, idx)` | `flir.local_partition` | Thread-local partition |
+| | `flir.local_tile(layout, tiler, coord)` | `flir.local_tile` | Extract tile at coordinate |
+
+---
+
+## 1. Core Types
+
+FLIR defines five custom MLIR types:
+
+| Type | MLIR Syntax | Description |
+|---|---|---|
+| `!flir.int` | `!flir.int` | Legacy integer type (compatibility) |
+| `!flir.shape<pattern>` | `!flir.shape<(8, 16)>` | Dimension extents -- can be nested |
+| `!flir.stride<pattern>` | `!flir.stride<(1, 8)>` | Memory strides -- can be nested |
+| `!flir.layout<shape:stride>` | `!flir.layout<(8, 16):(1, 8)>` | Layout = (Shape, Stride) pair |
+| `!flir.coord<pattern>` | `!flir.coord<(*, *)>` | Coordinate (flat, no nesting) |
+
+### Pattern Attributes
+
+Patterns encode the structure of shapes/strides/coords at the type level:
+
+| Pattern | Meaning | Example |
+|---|---|---|
+| Integer literal | Static constant | `8` |
+| `*` (`#flir.underscore`) | Wildcard (any value) | Used in rank-only types |
+| `?` (`#flir.dync_i32`) | Dynamic value (runtime) | SSA operand provides the value |
+| Nested tuple | Hierarchical mode | `(8, (4, 2))` |
+
+**Type-mode ops**: `make_shape`, `make_stride`, `make_coord` encode structure in the result type. Only dynamic leaves appear as SSA operands.
+
+---
+
+## 2. Construction
+
+### Python API
+
+```python
+from flydsl.dialects.ext import flir, arith
+
+# Constants
+c8 = arith.constant(8, index=True)
+c16 = arith.constant(16, index=True)
+c1 = arith.constant(1, index=True)
+
+# Basic construction
+shape = flir.make_shape(c8, c16)            # (8, 16)
+stride = flir.make_stride(c1, c8)           # (1, 8) -- column-major
+layout = flir.make_layout(shape, stride)    # ((8, 16), (1, 8))
+coord = flir.make_coord(i, j)              # (i, j)
+
+# Static constants (Python ints auto-materialized)
+shape = flir.make_shape(8, 16)              # Same as above
+layout = flir.make_layout((8, 16), (1, 8))  # Tuple shorthand
+
+# Nested shapes
+shape_nested = flir.make_shape(9, (4, 8))   # (9, (4, 8))
+
+# Ordered layout (convenience)
+layout_cm = flir.make_ordered_layout((8, 16), order=(1, 0))  # col-major
+layout_rm = flir.make_ordered_layout((8, 16), order=(0, 1))  # row-major
+```
+
+### MLIR
+
+```mlir
+// Create 2D layout (8, 16) with column-major stride (1, 8)
+%shape = flir.make_shape %c8, %c16 : (!flir.int, !flir.int) -> !flir.shape<2>
+%stride = flir.make_stride %c1, %c8 : (!flir.int, !flir.int) -> !flir.stride<2>
+%layout = flir.make_layout %shape, %stride
+    : (!flir.shape<2>, !flir.stride<2>) -> !flir.layout<2>
+%coord = flir.make_coord %i, %j : (index, index) -> !flir.coord<2>
+```
+
+---
+
+## 3. Coordinate Mapping
+
+The fundamental operation: mapping between logical coordinates and physical memory indices.
+
+**Formula**: `Index = dot(Coord, Stride) = sum(coord_i * stride_i)`
+
+### `crd2idx` -- Coordinate to Index
+
+```python
+# Python
+idx = flir.crd2idx(coord, layout)
+```
+
+```mlir
+// MLIR
+%idx = flir.crd2idx %coord, %layout : (!flir.coord<2>, !flir.layout<2>) -> index
+```
+
+### `idx2crd` -- Index to Coordinate (inverse)
+
+```python
+# Python
+coord = flir.idx2crd(idx, layout)
+```
+
+```mlir
+// MLIR
+%coord = flir.idx2crd %idx, %layout : (index, !flir.layout<2>) -> !flir.coord<2>
+```
+
+### Example
+
+For layout `((8, 16), (1, 8))` (8x16, column-major):
+- `crd2idx((3, 5), layout)` = `3*1 + 5*8` = `43`
+- `idx2crd(43, layout)` = `(43 % 8, 43 / 8)` = `(3, 5)`
+
+---
+
+## 4. Query Operations
+
+| Operation | Description | Example |
+|---|---|---|
+| `size(x)` | Product of all dimensions | `size((8, 16)) = 128` |
+| `cosize(layout)` | Span of the layout mapping (max index + 1) | `cosize(((8, 16), (1, 8))) = 128` |
+| `rank(x)` | Number of top-level dimensions | `rank((8, 16)) = 2` |
+| `get(x, i)` | Extract i-th element | `get((8, 16), 0) = 8` |
+| `get_shape(layout)` | Extract shape from layout | Returns `!flir.shape` |
+| `get_stride(layout)` | Extract stride from layout | Returns `!flir.stride` |
+
+```python
+s = flir.size(layout)       # total elements
+cs = flir.cosize(layout)    # codomain span
+r = flir.rank(layout)       # number of modes
+v = flir.get(shape, 0)      # first dimension
+
+shape = flir.get_shape(layout)
+stride = flir.get_stride(layout)
+```
+
+---
+
+## 5. Layout Algebra
+
+### 5.1 Composition: `composition(A, B)`
+
+Composes two layouts: result maps through B first, then A.
+
+**Semantics**: `result(x) = A(B(x))`
+
+```python
+composed = flir.composition(layout_a, layout_b)
+```
+
+```mlir
+%composed = flir.composition %layoutA, %layoutB
+    : (!flir.layout<2>, !flir.layout<2>) -> !flir.layout<2>
+```
+
+**Use case**: Applying a permutation to a layout, or composing a tile coordinate mapping with a memory layout.
+
+### 5.2 Complement: `complement(tiler, target_size)`
+
+Computes the "remaining" modes not covered by the tiler, up to `target_size` elements.
+
+```python
+rest = flir.complement(tiler, target_size)
+```
+
+**Algorithm**:
+1. Filter out stride-0 and size-1 modes from the tiler
+2. Sort modes by stride (ascending)
+3. Fold to compute rest modes
+
+**Use case**: Internal building block for `logical_divide`. Also useful for computing the complementary iteration space when tiling.
+
+### 5.3 Coalesce: `coalesce(layout)`
+
+Simplifies a layout by flattening nested modes and combining adjacent modes when possible.
+
+**Post-conditions**:
+- `size(result) == size(layout)` (preserves total size)
+- `result` has depth ≤ 1 (flattened)
+- For all valid indices: `layout(i) == result(i)` (preserves mapping)
+
+```python
+simplified = flir.coalesce(layout)
+```
+
+---
+
+## 6. Product Operations
+
+Products combine two layouts to create a larger layout. All products take `(block, tiler)` and produce a result layout.
+
+| Variant | Description |
+|---|---|
+| `logical_product` | Mode-wise concatenation (most basic). Scales tiler strides by block size. |
+| `zipped_product` | Interleaves modes from block and tiler. |
+| `tiled_product` | Creates hierarchical tiled structure. |
+| `flat_product` | Produces a flattened result. |
+| `raked_product` | Creates a raked (interleaved) access pattern. |
+| `blocked_product` | Creates a blocked access pattern. |
+
+```python
+result = flir.logical_product(block_layout, tiler_layout)
+result = flir.zipped_product(block_layout, tiler_layout)
+result = flir.raked_product(block_layout, tiler_layout)
+# ... etc
+```
+
+### Example
+
+```python
+# Thread layout: 4 threads along M, 32 along N
+thr_layout = flir.make_ordered_layout((4, 32), order=(1, 0))
+
+# Value layout: each thread handles 4x4 elements
+val_layout = flir.make_ordered_layout((4, 4), order=(1, 0))
+
+# Raked product: interleaved access across threads
+raked = flir.raked_product(thr_layout, val_layout)
+```
+
+---
+
+## 7. Divide Operations
+
+Divides partition a layout by a tiler, creating a view that separates "tile" and "rest" dimensions.
+
+| Variant | Description |
+|---|---|
+| `logical_divide` | Basic partitioning. Internally uses `complement`. |
+| `zipped_divide` | Zipped division semantics. |
+| `tiled_divide` | Hierarchical tiled division. |
+| `flat_divide` | Flattened division. |
+
+```python
+result = flir.logical_divide(layout, tiler)
+result = flir.zipped_divide(layout, tiler)
+```
+
+### `zipped_divide` with TensorView
+
+`zipped_divide` has special support for `TensorView` objects, enabling block-level tiling:
+
+```python
+tensor = flir.make_tensor(A, shape=(M, N), strides=(N, 1))
+tiles = flir.zipped_divide(tensor, (TILE_M, TILE_N))
+
+# Index with block coordinates to get a tile
+blk_tile = tiles[(flir.block_idx("y"), flir.block_idx("x"))]
+```
+
+---
+
+## 8. Local Partition & Tile
+
+### `local_partition(layout, tile, index)`
+
+Partitions a layout for a specific thread/block index:
+
+```python
+# Partition layout by tile for thread `tid`
+thr_portion = flir.local_partition(layout, tile_layout, tid)
+```
+
+### `local_tile(layout, tiler, coord)`
+
+Extracts a tile from a layout at specific coordinates:
+
+```python
+tile = flir.local_tile(layout, tile_shape, block_coord)
+```
+
+---
+
+## 9. Helper Functions
+
+### `make_ordered_layout(shape, order, stride)`
+
+Creates a layout with specified dimension ordering:
+
+```python
+# Column-major (N is the fast-changing dimension)
+layout_cm = flir.make_ordered_layout((M, N), order=(1, 0))
+
+# Row-major (M is the fast-changing dimension)
+layout_rm = flir.make_ordered_layout((M, N), order=(0, 1))
+```
+
+When `order` is provided, strides are computed automatically. When `stride` is provided instead, it's used directly.
+
+### `product_each(shape)`
+
+Element-wise product of nested shape dimensions:
+
+```python
+# If shape is ((4, 8), (2, 16)):
+# product_each returns (32, 32) -- products within each mode
+result = flir.product_each(shape)
+```
+
+### `make_layout_tv(thr_layout, val_layout)`
+
+Creates a tiler and TV (thread-value) layout from separate thread and value layouts. Used internally by `make_tiled_copy_tv`.
+
+---
+
+## 10. Swizzling
+
+### `swizzle_xor16(row, col, kBlocks16)`
+
+XOR-based swizzle for LDS bank-conflict avoidance at 16-byte granularity:
+
+**Formula**: `result = col XOR ((row % kBlocks16) * 16)`
+
+```python
+col_swizzled = flir.swizzle_xor16(row, col, k_blocks16)
+```
+
+```mlir
+%swizzled = flir.swizzle_xor16 %row, %col, %kBlocks16
+    : (index, index, index) -> index
+```
+
+This matches the CK/ROCDSL-style LDS swizzle used for FP8/F16 tiles where the K dimension is permuted at 16-byte granularity while preserving intra-16B order.
+
+**Usage in kernels**: Applied when storing tiles to LDS to avoid bank conflicts:
+
+```python
+# In preshuffle GEMM kernels:
+col_bytes = col_i32 * arith.constant(4, index=True)
+col_swz = flir.swizzle_xor16(row, col_bytes, k_blocks16)
+coord = flir.make_coord(row, col_swz)
+idx = flir.crd2idx(coord, lds_layout)
+```
+
+---
+
+## 11. Nested / Hierarchical Layouts
+
+FLIR supports nested layouts for representing multi-level tiling hierarchies:
+
+```python
+# Nested shape: 9 elements in first mode, (4, 8) = 32 elements in second
+shape = flir.make_shape(9, (4, 8))
+
+# This represents a 2-level hierarchy:
+# - Outer: 9 x 4
+# - Inner: 4 within each outer element, 8 within each inner group
+```
+
+Nested layouts are used in GEMM kernels for multi-level tiling (block → warp → thread → instruction).
+
+---
+
+## 12. Decision Tree
+
+```
+Which layout operation do I need?
+
+├── Creating a layout?
+│   ├── From explicit shape + stride → make_layout(shape, stride)
+│   ├── With dimension ordering → make_ordered_layout(shape, order)
+│   └── From existing layout components → make_layout(get_shape(l), new_stride)
+│
+├── Querying a layout?
+│   ├── Total elements → size(layout)
+│   ├── Memory span → cosize(layout)
+│   ├── Number of modes → rank(layout)
+│   └── Extract component → get(shape, i), get_shape(layout), get_stride(layout)
+│
+├── Coordinate mapping?
+│   ├── Coord → memory index → crd2idx(coord, layout)
+│   └── Memory index → coord → idx2crd(idx, layout)
+│
+├── Combining layouts?
+│   ├── Sequential mapping (A then B) → composition(A, B)
+│   ├── Extending to more threads → logical_product / raked_product / blocked_product
+│   └── Simplifying → coalesce(layout)
+│
+├── Partitioning / tiling?
+│   ├── Split layout into tiles → logical_divide / zipped_divide
+│   ├── Get one thread's portion → local_partition(layout, tile, thread_id)
+│   └── Get one block's tile → local_tile(layout, tile_shape, block_coord)
+│
+└── LDS bank-conflict avoidance?
+    └── XOR swizzle → swizzle_xor16(row, col, k_blocks16)
+```
+
+---
+
+## 13. Source Files
+
+| File | Description |
+|---|---|
+| `flir/include/flir/FlirOps.td` | All FLIR op definitions (construction, query, algebra, divide, product, local ops) |
+| `flir/include/flir/FlirTypeDefs.td` | Type definitions (`!flir.shape`, `!flir.stride`, `!flir.layout`, `!flir.coord`) |
+| `flir/include/flir/FlirAttrDefs.td` | Attribute definitions (`#flir.underscore`, `#flir.dync_i32`) |
+| `flir/lib/Dialect/Flir/FlirLayoutAlgebra.cpp` | Type inference for composition, logical_product, logical_divide |
+| `flir/lib/Dialect/Flir/FlirOps.cpp` | Op verifiers and custom builders |
+| `flydsl/src/flydsl/dialects/ext/flir.py` | Python API: all layout functions, TensorView, CopyAtom, TiledCopy |
+| `tests/pyir/test_layout_algebra.py` | Layout algebra tests (composition, complement, coalesce) |
+| `tests/pyir/test_product_divide.py` | Product and divide operation tests |
+| `tests/pyir/test_nested_layouts.py` | Nested/hierarchical layout tests |
+| `tests/pyir/test_local_ops.py` | local_partition and local_tile tests |

--- a/docs/prebuilt_kernels_guide.md
+++ b/docs/prebuilt_kernels_guide.md
@@ -1,0 +1,379 @@
+# Pre-built Kernel Library Guide
+
+> Available FlyDSL kernels: Normalization, Softmax, GEMM, Mixed-precision GEMM, MoE GEMM -- configuration, data types, pipelines, and shared utilities.
+
+## Quick Reference
+
+| Kernel | Builder Function | Dtypes | Key Feature |
+|---|---|---|---|
+| **LayerNorm** | `build_layernorm_module(M, N, dtype)` | f32, f16, bf16 | Two-pass vectorized normalization |
+| **RMSNorm** | `build_rmsnorm_module(M, N, dtype)` | f32, f16, bf16 | LDS-cached 3-pass pipeline |
+| **Softmax** | `build_softmax_module(M, N, dtype)` | f32, f16, bf16 | Online softmax, adaptive block size |
+| **GEMM** | `compile_preshuffle_gemm_a8(...)` | fp8, int8, int4, fp16, bf16 | Preshuffle B, ping-pong LDS, MFMA 16x16 |
+| **Mixed GEMM** | `compile_mxfp4_preshuffle_gemm(...)` | A:fp8/fp4, B:fp4 | MXFP4 mixed-precision with per-block scales |
+| **MoE GEMM** | `compile_moe_gemm1(...)` | fp8, fp16, int8, int4 | Dual accumulator, SiLU gating, expert routing |
+| **Mixed MoE GEMM** | `compile_mixed_moe_gemm1(...)` | A:fp8/fp4, B:fp4 | MXFP4 MoE with separate A/B scales |
+
+---
+
+## 1. Normalization Kernels
+
+### 1.1 LayerNorm (`kernels/layernorm_kernel.py`)
+
+Computes `LayerNorm(x) = (x - mean) / sqrt(var + eps) * gamma + beta` for each row.
+
+**Builder:**
+```python
+from kernels.layernorm_kernel import build_layernorm_module
+
+executor = build_layernorm_module(M=32768, N=8192, dtype_str="bf16")
+```
+
+**Configuration Constants:**
+| Constant | Value | Description |
+|---|---|---|
+| `BLOCK_THREADS` | 256 | Threads per block |
+| `WARP_SIZE` | 64 | AMD wavefront size |
+| `VEC_WIDTH` | 8 | Vector load/store width |
+| `VEC_ALIGN` | 16 | Alignment for vector ops (bytes) |
+| `EPS` | 1e-5 | Numerical stability epsilon |
+| `USE_NONTEMPORAL` | True | Non-temporal stores for output |
+
+**Algorithm:**
+- **Two-pass normalization**: Pass 1 computes mean and variance, Pass 2 applies affine transform
+- **Fast path**: When `N == BLOCK_THREADS * VEC_WIDTH * 4` (e.g., N=8192), uses fully register-resident computation with no scalar tail
+- **Generic path**: Handles arbitrary N with vector body + scalar tail
+- **bf16 handling**: Software round-to-nearest-even (RNE) pack on gfx942; hardware `cvt_pk_bf16_f32` on gfx950+
+- **Warp reduction**: XOR-shuffle-based intra-wave reduction (shifts: 32, 16, 8, 4, 2, 1), then LDS-based cross-wave synchronization
+
+**Kernel signature** (inside the `_LayerNorm` MlirModule):
+```
+GPU_MODULE_NAME = "layernorm_module"
+
+@kernel
+layernorm_kernel(self, Input, Gamma, Beta, Output, m_in)
+
+@jit
+__call__(self, Input, Gamma, Beta, Output, m_in)
+```
+
+### 1.2 RMSNorm (`kernels/rmsnorm_kernel.py`)
+
+Computes `RMSNorm(x) = x / sqrt(mean(x^2) + eps) * gamma`.
+
+**Builder:**
+```python
+from kernels.rmsnorm_kernel import build_rmsnorm_module
+
+executor = build_rmsnorm_module(M=32768, N=8192, dtype_str="bf16")
+```
+
+**Configuration Constants:** Same as LayerNorm (BLOCK_THREADS=256, VEC_WIDTH=8, etc.)
+
+**Algorithm (3-pass with LDS caching):**
+1. **Pass 0**: Global → LDS row cache (one-pass global read, vectorized)
+2. **Pass 1**: Sum-of-squares computation from LDS row cache
+3. **Pass 2**: Normalize + gamma multiply + store with software pipeline for Gamma prefetch
+
+**Kernel signature:**
+```
+GPU_MODULE_NAME = "rmsnorm_module"
+
+@kernel
+rmsnorm_kernel(self, Input, Gamma, Output, m_in)
+```
+
+---
+
+## 2. Softmax Kernel
+
+### 2.1 Softmax (`kernels/softmax_kernel.py`)
+
+Computes row-wise softmax: `softmax(x)_i = exp(x_i - max(x)) / sum(exp(x - max(x)))`.
+
+**Builder:**
+```python
+from kernels.softmax_kernel import build_softmax_module
+
+executor = build_softmax_module(M=32768, N=8192, dtype_str="bf16")
+```
+
+**Configuration:**
+| Parameter | Value | Description |
+|---|---|---|
+| `BLOCK_SIZE` | `min(256, next_power_of_2(N))`, min 32 | Adaptive block size |
+| `VEC_WIDTH` | 8 | Vector load/store width |
+| `WARP_SIZE` | 64 | AMD wavefront size |
+
+**Algorithm (6 stages):**
+1. **Load Data**: Vectorized global loads into register buffer with validity masks
+2. **Local Max**: Per-thread vector reduction (`maxnumf`)
+3. **Global Max**: Block-wide shuffle reduction (intra-wave XOR → wave0 finalize via LDS)
+4. **Local Exp + Sum**: `exp2(x * log2(e))` approximation, accumulate partial sums
+5. **Global Sum**: Block-wide reduction for sum
+6. **Normalize + Store**: Divide by sum, convert to output dtype, vectorized store
+
+**Kernel signature:**
+```
+GPU_MODULE_NAME = f"softmax_{dtype_str}"  # e.g., "softmax_bf16"
+
+@kernel
+softmax_kernel(self, A, C, m_in)
+```
+
+---
+
+## 3. GEMM Kernels
+
+### 3.1 Preshuffle GEMM (`kernels/preshuffle_gemm.py`)
+
+MFMA 16x16-based GEMM with B-matrix preshuffle layout: `C[M,N] = A[M,K] @ B[N,K]^T`.
+
+**Builder:**
+```python
+from kernels.preshuffle_gemm import compile_preshuffle_gemm_a8
+
+executor = compile_preshuffle_gemm_a8(
+    M=16, N=5120, K=8192,
+    tile_m=16, tile_n=128, tile_k=256,
+    in_dtype="fp8",
+    lds_stage=2,
+    use_cshuffle_epilog=False,
+)
+```
+
+**Parameters:**
+| Parameter | Type | Description |
+|---|---|---|
+| `M, N, K` | int | GEMM dimensions: A[M,K], B[N,K], C[M,N] |
+| `tile_m, tile_n, tile_k` | int | Block tile sizes |
+| `in_dtype` | str | `"fp8"`, `"int8"`, `"int4"`, `"fp16"`, `"bf16"` |
+| `lds_stage` | int | `2` = ping-pong LDS (tuned), `1` = single LDS buffer |
+| `use_cshuffle_epilog` | bool | CK-style LDS CShuffle epilogue |
+
+**Key constraints:**
+- `tile_m * tile_k * elem_bytes` must be divisible by `total_threads` (256)
+- `tile_k * elem_bytes` must be divisible by 64 (K64-byte micro-step)
+- INT4 is W4A8: A is int8, B is packed int4 (2 values/byte), unpacked to int8 in-kernel
+
+**Pipeline details:**
+- **lds_stage=2 (ping-pong)**: Two LDS buffers for A tiles. Cross-tile A0 prefetch overlaps VMEM with LDS reads
+- **lds_stage=1 (single)**: CK-style intrawave schedule with single LDS buffer
+- **K64-byte micro-step**: Each step issues 2x K32 MFMA operations (fp8/int8: 64 elements, fp16/bf16: 32 elements)
+- **XOR16 swizzle**: Byte-level swizzle on LDS to avoid bank conflicts
+- **B-preshuffle**: Shape (N0, K0, KLane, NLane, KPackBytes) = (N/16, K/64, 4, 16, kpack_bytes)
+- **CShuffle epilogue**: Write C tile to LDS in row-major, remap threads for half2 packing via `ds_bpermute`
+
+### 3.2 Mixed-Precision GEMM (`kernels/mixed_preshuffle_gemm.py`)
+
+MXFP4 mixed-precision GEMM with separate A/B quantization scales.
+
+**Builder:**
+```python
+from kernels.mixed_preshuffle_gemm import compile_mxfp4_preshuffle_gemm
+
+executor = compile_mxfp4_preshuffle_gemm(
+    M=16, N=5120, K=8192,
+    tile_m=16, tile_n=128, tile_k=256,
+    a_dtype="fp8", b_dtype="fp4",
+    lds_stage=2,
+    use_cshuffle_epilog=True,
+)
+```
+
+**Parameters:**
+| Parameter | Type | Description |
+|---|---|---|
+| `a_dtype` | str | `"fp8"` or `"fp4"` for A matrix |
+| `b_dtype` | str | `"fp4"` for B matrix |
+| `use_cshuffle_epilog` | bool | Default `True` for mixed GEMM |
+
+**Key features:**
+- K128 stepping with per-pack scale factors
+- Packed FP4 element handling (2 elements per byte)
+- Separate scale loading for A and B paths with `quant_block_size=32`
+- Uses `mfma_scale_x128` on gfx950+ (9-operand scaling MFMA)
+
+---
+
+## 4. MoE GEMM Kernels
+
+### 4.1 MoE GEMM 2-Stage (`kernels/moe_gemm_2stage.py`)
+
+Mixture-of-Experts GEMM with dual accumulators for gate/up projections and SiLU gating.
+
+**Stage 1 Builder:**
+```python
+from kernels.moe_gemm_2stage import compile_moe_gemm1
+
+executor = compile_moe_gemm1(
+    model_dim=8192, inter_dim=8192,
+    experts=16, topk=4,
+    tile_m=64, tile_n=128, tile_k=128,
+    doweight_stage1=True,
+    in_dtype="fp8", out_dtype="f16",
+)
+```
+
+**Parameters:**
+| Parameter | Type | Description |
+|---|---|---|
+| `model_dim` | int | Model hidden dimension |
+| `inter_dim` | int | Intermediate dimension |
+| `experts` | int | Number of experts |
+| `topk` | int | Top-K experts per token |
+| `tile_m, tile_n, tile_k` | int | Block tile sizes |
+| `doweight_stage1` | bool | Apply sorted weights in stage1 epilogue |
+| `in_dtype` | str | `"fp8"`, `"fp16"`, `"int8"`, `"int4"` |
+| `out_dtype` | str | `"f16"` or `"bf16"` |
+
+**Key features:**
+- **Dual accumulator**: `acc_gate` and `acc_up` for gate and up projections
+- **SiLU activation**: `silu(x) = x * sigmoid(x)` using `exp2` + `rcp` for efficiency
+- **Dynamic expert routing**: Expert ID lookup per M-tile
+- **Sorted token masking**: Sentinel value for out-of-bounds token safety
+- **Block validity gating**: Skip invalid M tiles early
+- **CShuffle epilogue**: Optional, with sorted weight and scale blending
+
+**Kernel signature:**
+```
+GPU_MODULE_NAME = f"mfma_moe1_{in_dtype}_{out_dtype}_{epilog_tag}_t{tile_m}x{tile_n}x{tile_k}_abi3"
+
+@kernel
+moe_gemm1(self, arg_out, arg_x, arg_w, arg_scale_x, arg_scale_w,
+          arg_sorted_token_ids, arg_expert_ids, arg_sorted_weights,
+          arg_max_token_ids, tokens_in, inter_in, k_in, size_expert_ids_in)
+```
+
+### 4.2 Mixed MoE GEMM (`kernels/mixed_moe_gemm_2stage.py`)
+
+MXFP4 variant of MoE GEMM combining dual-accumulator pattern with mixed-precision scales.
+
+**Builder:**
+```python
+from kernels.mixed_moe_gemm_2stage import compile_mixed_moe_gemm1
+
+executor = compile_mixed_moe_gemm1(
+    model_dim=8192, inter_dim=8192,
+    experts=16, topk=4,
+    tile_m=64, tile_n=128, tile_k=256,
+    doweight_stage1=True,
+    a_dtype="fp8", b_dtype="fp4",
+    out_dtype="f16",
+)
+```
+
+---
+
+## 5. Shared Utilities
+
+### 5.1 Reduction Helpers (`kernels/reduce.py`)
+
+Reusable warp and block reduction functions.
+
+| Function | Description |
+|---|---|
+| `reduce_vec_max(vec, VEC_WIDTH, ...)` | Vector reduction to max via `maxnumf` |
+| `reduce_vec_sum(vec, VEC_WIDTH, ...)` | Vector reduction to sum via `add` |
+| `make_block_reduce(tid, BLOCK_SIZE, ...)` | Block-wide reduction: intra-wave XOR shuffle → LDS cross-wave sync |
+| `make_block_reduce_add(tid, ...)` | Block reduction for addition (single-wave fast path) |
+| `make_block_reduce_add2(tid, ...)` | Dual independent scalar reduction |
+
+**Reduction pattern:**
+1. Intra-wave: XOR shuffle with shifts 32, 16, 8, 4, 2, 1 (wave64)
+2. Lane 0 writes per-wave partial to LDS
+3. Barrier
+4. Wave 0 reduces `NUM_WAVES` partials from LDS
+
+### 5.2 MFMA Epilogues (`kernels/mfma_epilogues.py`)
+
+Configurable epilogue strategies for MFMA 16x16 kernels.
+
+| Function | Description |
+|---|---|
+| `default_epilog(...)` | Standard row-iterator: `row = bx_m + mi*16 + lane_div_16*4 + ii` |
+| `c_shuffle_epilog(...)` | CK-style LDS CShuffle: write to LDS → barrier → remap threads (8,32) → half2 store |
+| `mfma_epilog(use_cshuffle, ...)` | Dispatcher: calls default or CShuffle based on flag |
+
+### 5.3 Preshuffle Pipeline (`kernels/mfma_preshuffle_pipeline.py`)
+
+Shared data movement and layout utilities for preshuffle GEMM/MoE kernels.
+
+| Function | Description |
+|---|---|
+| `make_preshuffle_b_layout(flir, arith, N, K, ...)` | Build B-preshuffle layout: (N/16, K/64, 4, 16, kpack_bytes) |
+| `make_preshuffle_scale_layout(...)` | Build scale layout for MXFP4 quantization |
+| `load_b_pack_k32(...)` | Load B pack for K32 MFMA micro-step (returns i64) |
+| `tile_chunk_coord_i32(...)` | Map (thread, chunk) → (row, col) for tile loads |
+| `buffer_copy_gmem16_dwordx4(...)` | 16-byte global load via buffer-load dwordx4 |
+| `lds_store_16b_xor16(...)` | Store 16B to LDS with XOR16 swizzle |
+| `lds_store_8b_xor16(...)` | Store 8B to LDS with XOR16 swizzle |
+| `lds_store_4b_xor16(...)` | Store 4B to LDS with XOR16 swizzle |
+| `lds_load_pack_k32(...)` | Load A-pack from LDS for K32 micro-step |
+
+---
+
+## 6. Kernel Decision Tree
+
+```
+What operation do you need?
+│
+├── Normalization
+│   ├── Need bias (beta) term? → LayerNorm (layernorm_kernel.py)
+│   └── No bias term?         → RMSNorm (rmsnorm_kernel.py)
+│
+├── Softmax
+│   └── Row-wise softmax      → Softmax (softmax_kernel.py)
+│
+├── Matrix Multiply (GEMM)
+│   ├── Standard GEMM (uniform precision)
+│   │   ├── FP8 / INT8 / INT4(W4A8) / FP16 / BF16
+│   │   └── → compile_preshuffle_gemm_a8()
+│   │
+│   ├── Mixed-precision GEMM (FP4 weights)
+│   │   ├── A: fp8 or fp4,  B: fp4
+│   │   └── → compile_mxfp4_preshuffle_gemm()
+│   │
+│   ├── MoE GEMM (expert routing)
+│   │   ├── Uniform precision (fp8/fp16/int8/int4)
+│   │   └── → compile_moe_gemm1()
+│   │
+│   └── Mixed MoE GEMM (FP4 expert weights)
+│       ├── A: fp8 or fp4,  B: fp4
+│       └── → compile_mixed_moe_gemm1()
+│
+└── Building blocks
+    ├── Warp/block reduction     → reduce.py
+    ├── MFMA epilogue selection  → mfma_epilogues.py
+    └── Preshuffle data movement → mfma_preshuffle_pipeline.py
+```
+
+---
+
+## 7. Source Files
+
+| File | Description |
+|---|---|
+| `kernels/__init__.py` | Package marker |
+| `kernels/kernels_common.py` | `stream_ptr_to_async_token()` helper |
+| `kernels/layernorm_kernel.py` | LayerNorm builder (`_LayerNorm` MlirModule) |
+| `kernels/rmsnorm_kernel.py` | RMSNorm builder (`_RMSNorm` MlirModule) |
+| `kernels/softmax_kernel.py` | Softmax builder (`_Softmax` MlirModule) |
+| `kernels/preshuffle_gemm.py` | Preshuffle GEMM builder (`_GEMM` MlirModule) |
+| `kernels/mixed_preshuffle_gemm.py` | Mixed-precision GEMM builder (`_GEMM` MlirModule) |
+| `kernels/moe_gemm_2stage.py` | MoE GEMM 2-stage builder (`_MOE1` MlirModule) |
+| `kernels/mixed_moe_gemm_2stage.py` | Mixed MoE GEMM builder (`_MOE1` MlirModule) |
+| `kernels/reduce.py` | Shared warp/block reduction helpers |
+| `kernels/mfma_epilogues.py` | MFMA epilogue strategies (default, CShuffle) |
+| `kernels/mfma_preshuffle_pipeline.py` | Preshuffle data movement and layout utilities |
+
+## 8. Test Files
+
+| File | Tests |
+|---|---|
+| `tests/kernels/test_layernorm.py` | LayerNorm correctness + perf vs PyTorch/AIter |
+| `tests/kernels/test_rmsnorm.py` | RMSNorm correctness + perf |
+| `tests/kernels/test_softmax.py` | Softmax correctness + perf vs PyTorch/AIter |
+| `tests/kernels/test_preshuffle_gemm.py` | GEMM fp8/int8/int4/bf16 correctness + perf |
+| `tests/kernels/test_moe_gemm.py` | MoE GEMM stage1/stage2 correctness + perf |
+| `tests/kernels/benchmark_common.py` | Shared benchmark infrastructure (FLIR vs AIter) |

--- a/docs/testing_benchmarking_guide.md
+++ b/docs/testing_benchmarking_guide.md
@@ -1,0 +1,454 @@
+# Testing & Benchmarking Guide
+
+> Test infrastructure, running tests, benchmark harness, writing new tests, and performance comparison with AIter.
+
+## Quick Reference
+
+| Category | Location | Requires GPU | Description |
+|---|---|---|---|
+| **MLIR IR tests** | `tests/mlir/*.mlir` | No | Verify FLIR → standard lowering |
+| **Python IR tests** | `tests/pyir/test_*.py` | No | Python-based MLIR generation + lowering |
+| **GPU kernel tests** | `tests/kernels/test_*.py` | Yes | Full compilation → GPU execution |
+| **Benchmarks** | `scripts/run_benchmark.sh` | Yes | Performance characterization |
+
+**Run all tests:**
+```bash
+bash scripts/run_tests.sh
+```
+
+**Run benchmarks:**
+```bash
+bash scripts/run_benchmark.sh
+```
+
+---
+
+## 1. Test Categories
+
+### 1.1 MLIR IR Tests (`tests/mlir/`)
+
+Direct MLIR lowering verification using the `flir-opt` tool. These tests validate that FLIR operations lower correctly to standard MLIR dialects without needing a GPU.
+
+**Files:**
+| Test File | Description |
+|---|---|
+| `test_basic.mlir` | Basic FLIR operation lowering |
+| `test_simple.mlir` | Simple layout operations |
+| `test_ops.mlir` | General FLIR ops |
+| `test_all_ops.mlir` | Comprehensive op coverage |
+| `test_crd2idx.mlir` | Coordinate-to-index mapping |
+| `test_idx2crd.mlir` | Index-to-coordinate mapping |
+| `test_size.mlir` | Size query operation |
+| `test_cosize.mlir` | Cosize query operation |
+| `test_rank.mlir` | Rank query operation |
+| `test_get.mlir` | Get (element access) operation |
+| `test_composition.mlir` | Layout composition |
+| `test_product_divide.mlir` | Product and divide operations |
+| `test_all_product_divide.mlir` | All product/divide variants |
+| `test_local_ops.mlir` | local_partition and local_tile |
+| `test_layout.mlir` | Layout construction |
+| `test_layout_amd.mlir` | AMD-specific layout patterns |
+| `test_chained.mlir` | Chained operations |
+| `test_chained_operations.mlir` | Complex chained sequences |
+| `test_coord_lowering.mlir` | Static coordinate lowering |
+| `test_coord_lowering_dynamic.mlir` | Dynamic coordinate lowering |
+| `test_pass.mlir` | Pass pipeline |
+| `comprehensive_test.mlir` | Full integration test |
+
+**Running individually:**
+```bash
+# Build flir-opt first if needed
+cmake --build .flir/build --target flir-opt -j$(nproc)
+
+# Run a single test
+.flir/build/bin/flir-opt --flir-to-standard tests/mlir/test_basic.mlir
+```
+
+### 1.2 Python IR Tests (`tests/pyir/`)
+
+Python-based tests that generate MLIR IR using the FlyDSL Python API and verify the IR structure and lowering. No GPU execution required.
+
+**Files:**
+| Test File | Description |
+|---|---|
+| `test_layout_algebra.py` | Layout algebra: coalesce, composition, divide, product, complement |
+| `test_product_divide.py` | Pythonic product/divide operator tests |
+| `test_local_ops.py` | Thread-level partitioning and tiling |
+| `test_nested_layouts.py` | Nested/hierarchical layout construction |
+| `test_basic_ops.py` | Basic FLIR operation generation |
+| `test_arith_operators.py` | Arithmetic operator overloading |
+| `test_passes.py` | Pipeline pass execution |
+| `test_static_vs_dynamic.py` | Static vs dynamic value handling |
+| `test_lang_module_descriptors.py` | MlirModule @kernel/@jit descriptors |
+| `test_rocdl_ops.py` | ROCm dialect operations |
+| `test_rocir_basic.py` | ROCm IR basic ops |
+| `test_rocir_coord_ops.py` | ROCm coordinate operations |
+| `test_rocir_product.py` | ROCm product operations |
+| `test_rocir_divide.py` | ROCm divide operations |
+| `test_rocir_local.py` | ROCm local operations |
+| `test_rocir_print.py` | ROCm IR printing |
+
+**Running individually:**
+```bash
+python tests/pyir/test_layout_algebra.py
+```
+
+### 1.3 GPU Kernel Tests (`tests/kernels/`)
+
+Full end-to-end tests: compile FlyDSL kernels to HSACO binary, execute on GPU, validate against PyTorch reference.
+
+**Files:**
+| Test File | Kernel | Description |
+|---|---|---|
+| `test_vec_add.py` | VecAdd | Vector addition (C = A + B) |
+| `test_softmax.py` | Softmax | Row-wise softmax |
+| `test_layernorm.py` | LayerNorm | Layer normalization |
+| `test_rmsnorm.py` | RMSNorm | RMS normalization |
+| `test_preshuffle_gemm.py` | GEMM | Preshuffle MFMA GEMM (fp8/int8/int4/bf16) |
+| `test_moe_gemm.py` | MoE GEMM | MoE 2-stage GEMM |
+| `test_eltwise_add.py` | EltAdd | Element-wise addition |
+| `test_matrix_trans.py` | Transpose | Matrix transpose |
+| `test_quant.py` | Quantization | Quantization ops |
+| `test_gpu_simple.py` | Simple GPU | Minimal GPU kernel test |
+| `test_gpu_layout.py` | Layout GPU | GPU layout operations |
+| `test_gpu_rocdsl.py` | ROCm DSL | ROCm DSL integration |
+| `test_gpu_with_rocir_coords.py` | Coords GPU | Coordinate operations on GPU |
+| `test_shared_working.py` | Shared Mem | Shared memory operations |
+| `test_ref.py` | Reference | Reference implementations |
+
+**Running individually:**
+```bash
+python tests/kernels/test_softmax.py
+python tests/kernels/test_preshuffle_gemm.py --in_dtype fp8 -M 16 -N 5120 -K 8192
+```
+
+---
+
+## 2. Test Runner Scripts
+
+### 2.1 `scripts/run_tests.sh`
+
+Main test orchestrator that runs all 4 test categories sequentially.
+
+**Environment setup:**
+```bash
+# Auto-detected PYTHONPATH
+PYTHONPATH="${REPO_ROOT}/flydsl/src:${BUILD_DIR}/python_packages/flydsl:${REPO_ROOT}:${PYTHONPATH}"
+```
+
+**Categories executed:**
+1. **MLIR IR tests**: Iterates `tests/mlir/*.mlir`, runs `flir-opt --flir-to-standard`
+2. **Python IR tests**: Runs `tests/pyir/test_*.py`
+3. **GPU execution tests**: Detects ROCm via `rocm-smi`, runs `tests/kernels/test_*.py`
+4. **GPU HIPGraph tests**: Runs GEMM/MoE tests with `-tg` flag for graph capture mode
+
+**Output:**
+- Logs to `/tmp/{test_name}.log`
+- Extracts performance metrics (TFLOPS, bandwidth) from output
+- Final summary with pass/fail counts
+
+### 2.2 `scripts/run_benchmark.sh`
+
+Specialized benchmarking harness for performance characterization.
+
+**Default configurations:**
+```bash
+# Softmax/LayerNorm
+SOFTMAX_SHAPES='32768,8192,bf16'
+LAYERNORM_SHAPES='32768,8192,bf16'
+
+# Preshuffle GEMM: "dtype,M,N,K,tile_m,tile_n,tile_k"
+GEMM_SHAPES='
+fp8,16,40960,5120,16,128,256
+fp8,16,77824,5120,16,128,256
+fp8,5120,5120,8320,64,256,128
+fp8,9728,8192,8320,64,256,128
+int8,9728,8192,8320,64,256,128
+'
+
+# MoE: "tokens,model_dim,inter_dim,experts,topk,tile_m,tile_n,tile_k,tile_n2,tile_k2"
+MOE_SHAPES='
+32768,8192,8192,16,4,64,128,128,256,128
+64,6144,1024,128,8,16,64,256,64,256
+'
+```
+
+**Selective execution:**
+```bash
+# Run only specific benchmarks
+bash scripts/run_benchmark.sh softmax
+bash scripts/run_benchmark.sh gemm moe
+bash scripts/run_benchmark.sh --only softmax,layernorm
+```
+
+**Logs:** Written to `${BENCH_LOG_DIR:-/tmp/flir_bench}/`
+
+---
+
+## 3. Pytest Configuration
+
+### 3.1 `tests/conftest.py`
+
+Pytest configuration with MLIR context fixtures.
+
+**Fixtures:**
+
+```python
+@pytest.fixture
+def ctx():
+    """Fresh MLIR context per test with FLIR dialects registered."""
+    # Creates Context, registers FLIR extensions, yields object with:
+    #   ctx.context, ctx.module, ctx.location
+
+@pytest.fixture
+def module(ctx):
+    """Provides ctx.module."""
+
+@pytest.fixture
+def insert_point(ctx):
+    """Sets insertion point to module body."""
+```
+
+**Build discovery:** Supports two build layouts:
+- Preferred: `.flir/build/python_packages/flydsl`
+- Fallback: `build/python_packages/flydsl`
+
+**Session hook:** Prevents pytest exit code 5 (no tests collected) from being treated as failure.
+
+---
+
+## 4. Performance Measurement
+
+### 4.1 `tests/test_common.py`
+
+Core performance testing utilities, adapted from AIter's test infrastructure.
+
+**`perftest()` decorator:**
+```python
+@perftest(num_iters=20, num_warmup=3, testGraph=False, num_rotate_args=0, needTrace=False)
+def my_kernel_test(Input, Output):
+    # Kernel invocation
+    ...
+```
+
+Features:
+- Device memory profiling to determine iteration count
+- Torch CUDA event timing
+- HIPGraph capture mode (`testGraph=True`)
+- Optional tensorboard trace profiling
+- Cache-aware iteration calculation
+
+**`checkAllclose()` function:**
+```python
+checkAllclose(output, reference, rtol=1e-2, atol=1e-2, tol_err_ratio=0.05)
+```
+Returns percent mismatch (0 = pass). Uses colored ANSI output for pass/fail indication.
+
+**`verify_output()` function:**
+```python
+verify_output(c_out, c_ref, atol=1e-2, rtol=1e-2, msg='')
+```
+High-level validation wrapper around `checkAllclose`.
+
+### 4.2 `tests/kernels/benchmark_common.py`
+
+Shared benchmark harness for FLIR vs AIter comparison.
+
+**Key types:**
+```python
+@dataclass(frozen=True)
+class PerfRow:
+    op: str           # e.g., "softmax"
+    shape: str        # e.g., "32768x8192"
+    dtype: str        # e.g., "bf16"
+    flir_gpu_us: Optional[float]
+    aiter_gpu_us: Optional[float]
+
+    @property
+    def speedup_aiter_vs_flir(self) -> Optional[float]:
+        ...  # flir_us / aiter_us
+```
+
+**Key functions:**
+```python
+# Measure device time (torch CUDA events)
+gpu_us = bench_gpu_us_torch(fn, warmup=20, iters=200)
+
+# Enable AIter comparison (best-effort)
+aiter_available = maybe_enable_aiter()  # respects AITER_REPO env var
+
+# Run comparative sweep
+rows = run_compare_sweep(configs=[(M, N, dtype), ...])
+print_perf_table(rows)
+```
+
+**Environment variables:**
+| Variable | Description | Default |
+|---|---|---|
+| `BENCH_CONFIGS` | Override benchmark configs | Default shapes |
+| `BENCH_WARMUP` | Warmup iterations | 10 |
+| `BENCH_ITERS` | Benchmark iterations | 50 |
+| `AITER_REPO` | Path to AIter repo for comparison | Auto-detect |
+
+---
+
+## 5. Writing New Tests
+
+### 5.1 PyIR Test Pattern
+
+```python
+# tests/pyir/test_my_feature.py
+from flydsl.dialects.ext import flir, arith
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+import _mlir.extras.types as T
+
+class _MyTest(MlirModule):
+    GPU_MODULE_NAME = "my_test"
+
+    @jit
+    def my_operation(self):
+        shape = flir.make_shape(4, 8)
+        stride = flir.make_stride(8, 1)
+        layout = flir.make_layout(shape, stride)
+        result = flir.size(layout)
+        return result
+
+def test_my_feature():
+    mod = _MyTest()
+    ir_str = str(mod.module)
+    # Verify IR contains expected operations
+    assert "flir.make_layout" in ir_str
+    assert "flir.size" in ir_str
+```
+
+### 5.2 GPU Kernel Test Pattern
+
+```python
+# tests/kernels/test_my_kernel.py
+import torch
+from tests.utils import compile_to_hsaco
+from tests.test_common import checkAllclose
+
+def test_my_kernel():
+    M, N = 1024, 1024
+    dtype = torch.float16
+
+    # 1. Build kernel
+    from kernels.my_kernel import build_my_module
+    executor = build_my_module(M, N, "f16")
+
+    # 2. Prepare data
+    input_tensor = torch.randn(M, N, dtype=dtype, device="cuda")
+    output_tensor = torch.empty_like(input_tensor)
+
+    # 3. Execute kernel
+    executor(input_tensor, output_tensor, M)
+
+    # 4. Reference
+    reference = torch.nn.functional.layer_norm(input_tensor, [N])
+
+    # 5. Validate
+    err = checkAllclose(output_tensor, reference, rtol=1e-2, atol=1e-2)
+    assert err == 0, f"Mismatch: {err}%"
+```
+
+### 5.3 Benchmark Test Pattern
+
+```python
+# Add to tests/kernels/test_my_kernel.py
+from tests.kernels.benchmark_common import bench_gpu_us_torch
+
+def benchmark_my_kernel():
+    executor = build_my_module(M, N, dtype)
+
+    # Wrap kernel call
+    def run():
+        executor(input_tensor, output_tensor, M)
+
+    # Measure
+    gpu_us = bench_gpu_us_torch(run, warmup=20, iters=200)
+
+    # Compute metrics
+    total_bytes = 2 * M * N * elem_size  # read input + write output
+    bandwidth_tbs = total_bytes / (gpu_us * 1e-6) / 1e12
+    print(f"Time: {gpu_us:.1f} us, Bandwidth: {bandwidth_tbs:.2f} TB/s")
+```
+
+---
+
+## 6. Test Configuration via Environment Variables
+
+| Variable | Used By | Description |
+|---|---|---|
+| `ROCDSL_SOFTMAX_SHAPES` | `test_softmax.py` | Override softmax test shapes (format: `"M,N,dtype;..."`) |
+| `ROCDSL_LAYERNORM_SHAPES` | `test_layernorm.py` | Override layernorm test shapes |
+| `ROCDSL_COMPARE_AITER` | kernel tests | Set to `1` to enable AIter comparison |
+| `FLIR_DUMP_IR` | `tests/utils.py` | Set to `1` to dump intermediate IR |
+| `FLIR_DUMP_DIR` | `tests/utils.py` | IR dump directory (default: `/tmp/flir_dump`) |
+| `FLIR_ENABLE_IR_PRINTING` | `tests/utils.py` | Print IR to console |
+| `FLIR_TIME_COMPILE` | `tests/utils.py` | Print per-stage compilation timing |
+| `FLIR_BUILD_DIR` | `conftest.py` | Override build directory path |
+
+---
+
+## 7. GEMM Test CLI Arguments
+
+The `test_preshuffle_gemm.py` test supports extensive CLI configuration:
+
+```bash
+python tests/kernels/test_preshuffle_gemm.py \
+    --in_dtype fp8 \
+    -M 16 -N 5120 -K 8192 \
+    --tile_m 16 --tile_n 128 --tile_k 256 \
+    --lds_stage 2 \
+    --num_iters 20 \
+    --num_warmup 3 \
+    --no_aiter_bench \
+    --test_graph        # or -tg for HIPGraph mode
+    --wfp4              # W4 (INT4) weight path
+```
+
+---
+
+## 8. Compilation Utilities (`tests/utils.py`)
+
+The `compile_to_hsaco()` function provides a standalone compilation path for tests:
+
+**Pipeline stages:**
+1. `flir-to-standard` lowering
+2. `trivial-dce` (dead code elimination)
+3. `canonicalize`
+4. `cse` (common subexpression elimination)
+5. Attach ROCDL target (auto-detect `gpu_arch`)
+6. `convert-gpu-to-rocdl` (SCF→CF, bare pointer memref)
+7. `gpu-to-llvm`
+8. `lower-to-llvm`
+9. `gpu-module-to-binary`
+
+**Weight utilities:**
+```python
+from tests.utils import pertoken_quant, shuffle_weight
+
+# Per-token quantization (handles NaN/Inf)
+quantized, scales = pertoken_quant(tensor, dtype=torch.float8_e4m3fnuz)
+
+# Weight preshuffle for MFMA (layout 16x16)
+shuffled = shuffle_weight(weight, layout=(16, 16))
+```
+
+---
+
+## 9. Source Files
+
+| File | Description |
+|---|---|
+| `scripts/run_tests.sh` | Main test orchestrator (4 categories) |
+| `scripts/run_benchmark.sh` | Benchmark harness with configurable shapes |
+| `tests/conftest.py` | Pytest fixtures (MLIR context, module, insert point) |
+| `tests/test_common.py` | `perftest()`, `checkAllclose()`, `verify_output()` |
+| `tests/utils.py` | `compile_to_hsaco()`, `pertoken_quant()`, `shuffle_weight()` |
+| `tests/kernels/benchmark_common.py` | `PerfRow`, `bench_gpu_us_torch()`, `print_perf_table()` |
+| `tests/mlir/*.mlir` | MLIR IR lowering tests (22 files) |
+| `tests/pyir/test_*.py` | Python IR generation tests (16 files) |
+| `tests/kernels/test_*.py` | GPU kernel tests (15 files) |
+| `tests/kernels/utils/fp4_utils.py` | FP4 packing/shuffling utilities |


### PR DESCRIPTION
## Summary

- Add 6 documentation guides covering all major FlyDSL subsystems:
  - **Architecture Guide** — Compilation pipeline (DSL → FLIR → MLIR → HSACO), project structure, environment variables, caching
  - **Layout System Guide** — FLIR layout algebra (Shape, Stride, Layout, Coord), all operations (composition, product, divide, partition), swizzling
  - **Kernel Authoring Guide** — MlirModule pattern, thread/block hierarchy, TensorView, tiled copies, MFMA, shared memory (SmemAllocator)
  - **Pre-built Kernels Guide** — All 7 kernel types (LayerNorm, RMSNorm, Softmax, Preshuffle GEMM, Mixed GEMM, MoE GEMM, Mixed MoE GEMM), builder APIs, configurations
  - **Testing & Benchmarking Guide** — Test categories (MLIR/PyIR/GPU), runner scripts, pytest fixtures, benchmark infrastructure (PerfRow, bench_gpu_us_torch)
  - **CuteDSL → FlyDSL Porting Guide** — Concept mapping from NVIDIA CuteDSL to FlyDSL, layout algebra equivalences, MMA→MFMA, VecAdd porting example, GEMM checklist
- Update README.md with a Documentation table linking to all guides

## Test plan

- [ ] Verify all guide links in README.md resolve correctly
- [ ] Spot-check code examples against actual source files
- [ ] Verify all file paths referenced in Source Files tables exist