### PR TITLE
Add Flash Attention V4.x kernel series with MFMA 16x16x16

### DIFF
--- a/.claude/skills/gpu-kernel-optimize/SKILL.md
+++ b/.claude/skills/gpu-kernel-optimize/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: gpu-kernel-optimize
+description: Systematic GPU kernel optimization workflow for FlyDSL kernels on AMD MI300X. Profile, identify bottleneck, apply targeted fix, measure, iterate.
+argument-hint: "<kernel-name and target config, e.g. 'flash_attention B=1 H=64 D=128 S=8192'>"
+---
+
+# GPU Kernel Optimization Workflow
+
+Systematic process for optimizing FlyDSL GPU kernels on AMD MI300X (GFX942). This skill encodes the methodology proven during Flash Attention optimization (V4.0→V4.2+exit: 26→108 TFLOPS, 4.1x improvement).
+
+## Core Principle: Profile-Driven Optimization
+
+**NEVER guess what to optimize.** Always measure first, identify the dominant bottleneck, fix it, then re-measure. Each iteration should target a single bottleneck category.
+
+## Step 1: Establish Baseline
+
+Run the kernel benchmark at the target configuration from `$ARGUMENTS`:
+
+```bash
+cd /home/pensun/FlyDSL
+python3 tests/kernels/test_<kernel>.py --batch B --num_heads H --head_dim D --seq_len S --warmup 10 --iters 50
+```
+
+Record: time (us), TFLOPS, correctness (max_err, cos_sim).
+
+If a reference implementation exists (ASM, CK, PyTorch), also measure it. **Ensure FLOP formulas match** — a common pitfall is comparing causal TFLOPS (÷2) against non-causal TFLOPS.
+
+## Step 2: Profile with rocprof
+
+Create counter config files. Use **two passes** (rocprof v2 limits ~8 counters per pass):
+
+**Pass 1** — Instruction mix:
+```
+pmc: SQ_WAVES SQ_INSTS_VALU SQ_INSTS_VMEM_RD SQ_INSTS_VMEM_WR SQ_INSTS_LDS SQ_INSTS_VALU_MFMA_MOPS_F16 SQ_BUSY_CU_CYCLES GRBM_GUI_ACTIVE
+```
+
+**Pass 2** — Latency/stalls:
+```
+pmc: SQ_WAVES SQ_INSTS_SALU SQ_INSTS_SMEM SQ_ACTIVE_INST_VALU SQ_ACTIVE_INST_LDS SQ_ACTIVE_INST_VMEM SQ_LEVEL_WAVES SQ_WAIT_INST_LDS
+```
+
+Run profiling:
+```bash
+rocprof --pmc-file /tmp/counters1.txt -o /tmp/prof1.csv python3 tests/kernels/test_<kernel>.py <args>
+rocprof --pmc-file /tmp/counters2.txt -o /tmp/prof2.csv python3 tests/kernels/test_<kernel>.py <args>
+```
+
+**Important**: Use supported GFX942 counters only. Avoid TCC_HIT and other unsupported counters.
+
+## Step 3: Analyze Profile — Identify Bottleneck Category
+
+Compute per-wave metrics by dividing raw counters by SQ_WAVES. Key ratios:
+
+### Bottleneck identification decision tree:
+
+```
+SQ_WAIT_INST_LDS / SQ_ACTIVE_INST_VALU > 1.5?
+├── YES → LDS-BOUND (latency or bandwidth)
+│   ├── High SQ_INSTS_LDS per wave? → Reduce LDS traffic (see Optimization Menu)
+│   └── Low SQ_INSTS_LDS but high wait? → Bank conflicts (see Optimization Menu)
+│
+└── NO → Check MFMA utilization
+    ├── SQ_INSTS_VALU_MFMA_MOPS / SQ_ACTIVE_INST_VALU < 0.5? → Instruction overhead
+    │   └── Too many non-MFMA instructions between MFMAs (barriers, address calc)
+    │
+    └── SQ_LEVEL_WAVES < 2? → Occupancy-bound
+        └── Check: LDS per workgroup (need <16KB for 4 waves/SIMD on MI300X)
+            VGPRs per wave (need <128 arch_vgpr for 4 waves/SIMD)
+```
+
+### Key thresholds (MI300X):
+- **LDS**: 64KB per CU, 4 SIMDs per CU → 16KB per SIMD for 4 waves
+- **VGPRs**: 512 per SIMD → 128 per wave for 4 waves
+- **Accum VGPRs**: 512 per SIMD → 128 per wave for 4 waves
+- **Barriers**: Each `s_barrier` costs ~100 cycles. Minimize barriers per iteration.
+
+## Step 4: Apply Targeted Optimization
+
+See the **Optimization Menu** below. Pick the optimization that addresses the identified bottleneck.
+
+## Step 5: Verify and Iterate
+
+1. **Correctness first**: Run full test suite. Must pass (max_err < 1e-2, cos_sim > 0.99)
+2. **Benchmark**: Compare old vs new at same config
+3. **Re-profile**: Verify the bottleneck shifted (e.g., LDS wait ratio dropped)
+4. **Update memory**: Record what changed and the measured impact
+5. **Go to Step 3**: Identify the new dominant bottleneck
+
+---
+
+## Optimization Menu
+
+### A. Reduce LDS Traffic
+
+**Problem**: High SQ_INSTS_LDS and SQ_WAIT_INST_LDS per wave.
+
+| Technique | When to Use | Expected Impact |
+|-----------|-------------|-----------------|
+| **Q-in-registers** | Q is re-read from LDS every KV iteration | Eliminates N×K_STEPS LDS reads from inner loop. FA V4.0→V4.1: LDS ops 40K→32K/wave |
+| **Increase BLOCK_N** | Many small iterations with barrier overhead | Halves iterations and barriers. FA V4.1→V4.2: BLOCK_N=16→32, 1.12x at S=8192 |
+| **Vectorized LDS loads** | Scalar LDS loads for B-operand of MFMA | Store data transposed so B-operand is contiguous → v4f16 load. FA V4.0→V4.1: key enabler |
+
+**Implementation pattern for Q-in-registers**:
+```python
+# Before KV loop: preload Q A-operand packs from LDS
+q_a_packs = []
+for ks in range_constexpr(K_STEPS):
+    q_lds_idx = <compute from wave offset, lane, ks>
+    q_a_packs.append(arith.as_value(
+        vec_ext.load_op(v4f16_type, lds_q, [q_lds_idx])
+    ))
+# Inside KV loop: use q_a_packs[ks] directly, no LDS reads for Q
+```
+
+**Implementation pattern for transposed V in LDS**:
+```python
+# V[row, col] stored at lds[col * VT_STRIDE + row] (transposed)
+# Cooperative store: extract each element, scatter-store
+for e in range_constexpr(VEC_WIDTH):
+    elem = arith.as_value(vec_ext.extract(vec, static_position=[e], ...))
+    col_e = (arith.ArithValue(load_col_base) + e).value
+    lds_idx = (arith.ArithValue(col_e) * VT_STRIDE + arith.ArithValue(load_row)).value
+    _memref.StoreOp(elem, lds_kv, [lds_idx])
+
+# B-operand load: now contiguous v4f16
+v_lds_idx = ((ds * 16 + arith.ArithValue(lane_mod_16)) * VT_STRIDE
+             + arith.ArithValue(lane_div_16) * 4).value
+v_pack = arith.as_value(vec_ext.load_op(v4f16_type, lds_kv, [v_lds_idx]))
+```
+
+### B. Fix Bank Conflicts
+
+**Problem**: Low SQ_INSTS_LDS but high SQ_WAIT_INST_LDS — bank conflicts.
+
+| Technique | Formula | Example |
+|-----------|---------|---------|
+| **Padding** | stride = size + PAD, where (stride/element_size) is odd | K_STRIDE = HD+2 = 130 (130/2=65, odd, coprime with 32 banks) |
+| **Swizzle** | XOR-based address permutation | `swizzle_xor16` for 16-element rotations |
+
+**Why PAD=2 works**: LDS has 32 banks, each 4 bytes. For f16 (2 bytes), two elements per bank. stride/2 must be odd (coprime with 32) so consecutive rows map to different banks. HD=128 → 128/2=64 (even, conflicts!) → (128+2)/2=65 (odd, no conflicts).
+
+### C. Reduce Barrier Overhead
+
+**Problem**: Many barriers per iteration eating into useful compute.
+
+| Technique | When | Impact |
+|-----------|------|--------|
+| **Increase BLOCK_N** | Barriers are per-iteration | 2x BLOCK_N → half iterations → half barriers |
+| **Fuse loads** | Separate K and V loads with barrier between | Single load phase + single barrier |
+| **Double-buffering (ping-pong)** | Load next tile while computing current | Eliminates load→compute barrier chain |
+
+### D. Reduce Wasted Compute
+
+**Problem**: Kernel computes results that are discarded (e.g., causal masking).
+
+| Technique | When | Impact |
+|-----------|------|--------|
+| **Causal early-exit** | Causal attention iterates past mask boundary | Loop to `q_start + BLOCK_M` instead of `seq_len`. ~1.6x at S=8192 (theoretical 2x) |
+| **Tile-level skip** | Entire tiles produce zero output | Skip tiles where `kv_start > q_end` |
+
+**Implementation**:
+```python
+if CAUSAL:
+    kv_upper = (arith.ArithValue(q_start) + BLOCK_M).value
+else:
+    kv_upper = seq_len_v
+with scf.for_(0, kv_upper, BLOCK_N, iter_args=init_args) as loop:
+```
+
+### E. Increase Occupancy
+
+**Problem**: SQ_LEVEL_WAVES < 2, low SIMD utilization.
+
+| Resource | Limit for 4 waves/SIMD | How to Reduce |
+|----------|----------------------|---------------|
+| LDS | < 16KB per workgroup | Reduce tile sizes, recompute instead of store |
+| Arch VGPRs | < 128 per wave | Reduce live register pressure, spill to LDS |
+| Accum VGPRs | < 128 per wave | Smaller MFMA accumulator tiles |
+
+### F. Scale Up Tile Size
+
+**Problem**: Per-tile overhead (launch, address calc) dominates small tiles.
+
+| Technique | Tradeoff |
+|-----------|----------|
+| **BLOCK_M=128** | 2x Q rows per tile → halves tile count, better Q amortization. Needs 8 waves. |
+| **BLOCK_M=256** | 4x Q rows (ASM uses this). Needs careful register/LDS management. |
+
+### G. Use Larger MFMA
+
+| Current | Target | Benefit |
+|---------|--------|---------|
+| `mfma_16x16x16f16` | `mfma_32x32x8f16` | 4x more output elements per instruction, fewer loop iterations |
+
+**Tradeoff**: 32x32 MFMA uses more accum VGPRs (16×v4f32 = 64 VGPRs vs 4×v4f32 = 16 VGPRs).
+
+### H. Q-from-Global Memory (bypass LDS for Q)
+
+**Problem**: Q in LDS wastes capacity when Q is only read once per KV loop.
+
+Load Q directly from global memory into MFMA registers. Each lane loads its v4f16 A-operand:
+```python
+# Each MFMA lane loads Q[q_row, ks*16 + b*4 : +4] directly from global
+q_row = q_start + wave_q_offset + lane_mod_16
+for ks in range_constexpr(K_STEPS):
+    q_col = ks * 16 + lane_div_16 * 4
+    g_idx = q_row * HEAD_DIM + q_col
+    q_a_packs[ks] = vec_ext.load_op(v4f16_type, Q_global, [g_idx])
+```
+
+**Impact**: Eliminates Q LDS (e.g., 16KB → 0). Partially coalesced (4 threads share 8-byte chunks).
+**Caveat**: No perf gain if VGPRs are the occupancy bottleneck (V4.3 lesson).
+
+### I. K/V Double-Buffering in LDS (from MI350 FMHA design)
+
+**Problem**: Stall waiting for global→LDS load to complete before computing.
+
+Allocate 2x LDS for K/V. Ping-pong between buffers:
+```
+Iteration i: Compute GEMM on buffer[i%2], Load next K/V into buffer[(i+1)%2]
+```
+**Requires**: 2x LDS for KV tiles. On MI300X with 64KB LDS, feasible for small tiles.
+
+### J. S/P Ping-Pong in VGPRs (from MI350 FMHA design)
+
+**Problem**: P→LDS→VGPR roundtrip between GEMM1 (Q@K^T→S→P) and GEMM2 (P@V).
+
+Keep P in VGPRs. GEMM1 produces S in accumulators → softmax → P stays in registers.
+Use GEMM ordering **K^T × Q^T** (not Q × K^T) so P is in A-operand format for GEMM2.
+**Key insight**: Transposed GEMM ordering matches MFMA data layout, avoiding P LDS roundtrip.
+
+### K. XDL || Softmax Co-Execution (from MI350 FMHA design)
+
+**Problem**: Softmax ALU runs sequentially after GEMM1, wasting MFMA execution units.
+
+On GFX942+, MFMA (XDL) and VALU can co-execute. Interleave softmax ALU with GEMM2 MFMA:
+```
+Step 1: GEMM1(K^T × Q^T) → S in accumulators
+Step 2: Softmax ALU on S [overlapped with] GEMM2(V^T × P) from PREVIOUS iteration
+```
+**Requires**: S/P ping-pong (technique J) to overlap current softmax with previous GEMM2.
+
+---
+
+## Pitfalls and Lessons Learned
+
+1. **FLOP formula mismatch**: ASM benchmarks often use non-causal formula `4*H*S*S*D` even for causal kernels. Our benchmarks use causal formula `4*H*S*(S/2)*D`. Always normalize before comparing. The "gap" can appear 2x worse than reality.
+
+2. **rocprof counter support**: Not all counters work on all architectures. `TCC_HIT` is unsupported on GFX942. If profiling fails, check counter names against `rocprof --list-counters`.
+
+3. **Two-pass profiling**: rocprof v2 limits counters per pass. Split into instruction-mix pass and latency/stall pass. Always include SQ_WAVES in both for per-wave normalization.
+
+4. **ArithValue wrapping**: FlyDSL's `scf.for_` returns ArithValue-wrapped iter_args. Always unwrap with `arith.as_value()` before passing to MLIR op constructors. The `induction_variable` also needs unwrapping.
+
+5. **Barrier count matters**: Each `s_barrier`/`gpu.barrier()` costs ~100 cycles. With 512 iterations and 4 barriers/iter, that's 200K wasted cycles. Halving iterations (larger BLOCK_N) directly halves this.
+
+6. **Causal early-exit gets < 2x**: Theoretical is 2x (skip half the KV positions on average). Practical is ~1.6x due to launch overhead and the smallest tiles (near diagonal) doing minimal work.
+
+7. **Profile the right kernel**: rocprof CSV may contain multiple kernel entries (compilation helpers, etc.). Find the actual kernel by name (e.g., `flash_attention_v4_1_kernel.kd`) and use its row.
+
+8. **LLVM AMDGPU scheduler reorders across barriers**: The LLVM backend can move `ds_read` (LDS read) instructions past `s_barrier` synchronization points, breaking intended LDS overlay patterns. Confirmed by comparing MLIR IR (correct order) vs final ISA (reordered). `rocdl.s_waitcnt(0)` does NOT act as a scheduling barrier — LLVM ignores it. **Never rely on LDS overlay with separate read/write phases unless you can prove LLVM won't reorder.**
+
+9. **AGPRs inaccessible from MLIR path**: MI300X has 256 arch VGPRs + 256 accum VGPRs (AGPRs). The LLVM flag `--greedy-reverse-local-assignment` has no effect on MFMA accumulator allocation. To use AGPRs, you need HipKittens-style inline assembly with explicit register pinning. ~20% improvement possible from eliminating AGPR↔VGPR copies.
+
+10. **Q-from-global doesn't improve perf if VGPR-limited**: V4.3 reduced LDS from 23KB→12.5KB but performance stayed at ~108 TFLOPS because 124 VGPRs still limit occupancy to 4 waves/SIMD. LDS reduction only helps if it's the occupancy bottleneck.
+
+---
+
+## Reference: Flash Attention Optimization History
+
+| Version | Change | S=8192 TFLOPS | Speedup | Key Metric Change |
+|---------|--------|---------------|---------|-------------------|
+| V4.0 | Baseline (BM=64,BN=16) | 26.3 | 1.0x | LDS wait/VALU = 3.05x |
+| V4.1 | +Q-regs, +V-transpose, +padding | 60.1 | 2.3x | LDS wait/VALU = 0.53x |
+| V4.2 | +BLOCK_N=32 | 67.6 | 2.6x | Half iterations/barriers |
+| V4.2+exit | +causal early-exit | 108.2 | 4.1x | Skip ~50% KV work |
+| V4.3 | +Q-from-global (LDS 23→12.5KB) | ~108 | 4.1x | LDS freed but VGPR-limited |
+| ASM v3 | Hand-tuned assembly | 1012 | — | BM=256,mfma_32x32 |
+
+Gap: 4.7x (using consistent FLOP convention).
+
+### V4.3 Notes
+- LDS overlay approach (reusing Q LDS for KV+P) FAILED due to LLVM scheduler reordering reads past barriers
+- Q-from-global approach works: each MFMA lane loads v4f16 directly from global memory
+- No perf improvement because 124 VGPRs (not LDS) limit occupancy to 4 waves/SIMD
+- AGPRs not usable from MLIR — would need inline ASM (HipKittens approach)
+
+### Remaining 4.7x Gap Analysis
+| Factor | Our V4.3 | ASM v3 | Impact |
+|--------|---------|--------|--------|
+| Tile size | BM=64 | BM=256 | 4x Q amortization |
+| MFMA size | 16x16x16 | 32x32x8 | 4x output/instr |
+| K/V buffering | Single | Double (ping-pong) | Hides global→LDS latency |
+| P path | P→LDS→VGPR | P in VGPRs (S/P ping-pong) | Eliminates roundtrip |
+| Softmax | Sequential | XDL \|\| ALU co-exec | Hides softmax latency |
+| Wave groups | 1 group | 2 staggered groups | LDS BW sharing |
+| Reductions | XOR shuffle | V_PERMLANE16/32_SWAP | Faster reduction |
+| AGPRs | None | Full AGPR usage | More register space |

--- a/.claude/skills/mfma-kernel-patterns/SKILL.md
+++ b/.claude/skills/mfma-kernel-patterns/SKILL.md
@@ -1,0 +1,526 @@
+---
+name: mfma-kernel-patterns
+description: Technical reference for AMD MFMA instruction patterns in FlyDSL kernels. Thread mapping, LDS layouts, cooperative loads, softmax, and P@V GEMM patterns.
+argument-hint: "<topic, e.g. 'mfma thread mapping', 'bank-conflict-free LDS', 'cooperative load', 'flash attention softmax'>"
+---
+
+# MFMA Kernel Patterns for FlyDSL
+
+Reference for writing high-performance MFMA-based GPU kernels in FlyDSL on AMD MI300X (GFX942). Distilled from Flash Attention V4.x development.
+
+Based on `$ARGUMENTS`, find the relevant section below and provide the pattern with FlyDSL code.
+
+---
+
+## 1. MFMA Thread Mapping — `mfma_f32_16x16x16f16`
+
+### Instruction semantics
+- **C[16,16] += A[16,16] × B[16,16]** in f16→f32
+- K=16 elements consumed per instruction
+- Inputs: A, B as `v4f16`, output/accumulator C as `v4f32`
+
+### Thread-to-element mapping (64 threads per wavefront)
+```
+lane = thread_id % 64
+b = lane // 16       # b ∈ {0,1,2,3} — "batch" within the 16x16 tile
+n = lane % 16        # n ∈ {0,1,...,15} — column index
+
+C output:  lane owns C[b*4+ii, n] for ii=0,1,2,3  → v4f32
+A operand: lane provides A[n, b*4 : b*4+4]        → v4f16 (4 consecutive K elements)
+B operand: lane provides B[b*4 : b*4+4, n]        → v4f16 (4 elements from consecutive rows)
+```
+
+### FlyDSL invocation
+```python
+from flydsl.dialects.ext import rocdl, arith, vec_ext
+
+v4f16_type = VectorType.get([4], F16Type.get())
+v4f32_type = VectorType.get([4], F32Type.get())
+
+# acc = A @ B + acc
+acc = arith.as_value(
+    rocdl.mfma_f32_16x16x16f16(
+        v4f32_type, [a_pack, b_pack, acc, 0, 0, 0]
+    )
+)
+# Last 3 args: cbsz=0, abid=0, blgp=0 (no broadcast)
+```
+
+### Loading A-operand from row-major LDS
+A[n, b*4:b*4+4] — thread needs 4 consecutive elements from row `n`, starting at column `b*4`:
+```python
+# Q stored row-major in LDS: Q[row, col] at lds[row * STRIDE + col]
+a_lds_idx = (
+    arith.ArithValue(lane_mod_16) * STRIDE   # row = n = lane%16
+    + ks * 16                                  # K-step offset
+    + arith.ArithValue(lane_div_16) * 4        # col = b*4
+).value
+a_pack = arith.as_value(vec_ext.load_op(v4f16_type, lds, [a_lds_idx]))
+```
+
+### Loading B-operand from row-major LDS
+B[b*4:b*4+4, n] — thread needs 4 elements from 4 consecutive rows at column `n`:
+```python
+# K stored row-major: K[row, col] at lds[row * K_STRIDE + col]
+# Need rows b*4, b*4+1, b*4+2, b*4+3 at column n
+# These are NOT contiguous in memory → 4 scalar loads (slow!)
+# Solution: transpose in LDS (see Section 4)
+```
+
+### Loading B-operand from TRANSPOSED LDS (preferred)
+V stored as V^T: V[row,col] at lds[col * VT_STRIDE + row]:
+```python
+# B-operand for P@V: need V^T[b*4:b*4+4, n] which is contiguous
+v_lds_idx = (
+    (ds * 16 + arith.ArithValue(lane_mod_16)) * VT_STRIDE  # col = ds*16+n
+    + arith.ArithValue(lane_div_16) * 4                      # row = b*4
+).value
+v_pack = arith.as_value(vec_ext.load_op(v4f16_type, lds_kv, [v_lds_idx]))
+```
+
+---
+
+## 2. Bank-Conflict-Free LDS Padding
+
+### Problem
+LDS has 32 banks, each 4 bytes wide. For f16 (2 bytes), 2 elements per bank.
+When stride is a multiple of 64 elements (e.g., HD=128), all threads in a wavefront
+accessing the same column hit the same bank → 32-way conflict.
+
+### Solution: Pad stride so stride/2 is odd
+```python
+PAD = 2  # minimum padding for f16
+K_STRIDE = HEAD_DIM + PAD   # e.g., 128+2=130, 130/2=65 (odd, coprime with 32)
+VT_STRIDE = BLOCK_N + PAD   # e.g., 32+2=34, 34/2=17 (odd, coprime with 32)
+```
+
+### Why it works
+- Bank index = (byte_offset / 4) % 32
+- For f16 at lds[row * stride + col]: byte_offset = (row * stride + col) * 2
+- Bank = (row * stride + col) / 2 % 32
+- If stride/2 is odd, consecutive rows map to different banks (stride/2 mod 32 ≠ 0)
+- 65 mod 32 = 1 → perfect stride for HD=128
+
+### LDS allocation
+```python
+LDS_Q_SIZE = BLOCK_M * K_STRIDE           # Q tile with padding
+LDS_KV_SIZE = max(
+    BLOCK_N * K_STRIDE,                    # K tile (row-major, padded)
+    HEAD_DIM * VT_STRIDE                   # V^T tile (transposed, padded)
+)
+# Total LDS = (LDS_Q_SIZE + LDS_KV_SIZE) * sizeof(f16)
+```
+
+---
+
+## 3. Cooperative Tile Load (Global → LDS)
+
+### Pattern: 256 threads loading a [ROWS, COLS] tile with vectorized loads
+
+```python
+VEC_WIDTH = 8                                    # v8f16 = 16 bytes per load
+THREADS_PER_ROW = HEAD_DIM // VEC_WIDTH          # e.g., 128/8 = 16
+ROWS_PER_BATCH = NUM_THREADS // THREADS_PER_ROW  # e.g., 256/16 = 16
+NUM_BATCHES = BLOCK_M // ROWS_PER_BATCH          # e.g., 64/16 = 4
+
+# Thread assignment
+load_col_base = (thread_in_block % THREADS_PER_ROW) * VEC_WIDTH
+load_row_in_batch = thread_in_block // THREADS_PER_ROW
+
+# Load loop
+for batch in range_constexpr(NUM_BATCHES):
+    row = tile_start + load_row_in_batch + batch * ROWS_PER_BATCH
+    g_idx = row * total_cols + load_col_base
+    vec = arith.as_value(vec_ext.load_op(v8f16_type, global_mem, [g_idx]))
+    lds_idx = (load_row_in_batch + batch * ROWS_PER_BATCH) * STRIDE + load_col_base
+    vec_ext.store(vec, lds, [lds_idx])
+```
+
+### Bounds checking (when tile may exceed data bounds)
+```python
+from flydsl.dialects.ext.scf import IfOp
+row_ok = arith.as_value(
+    flir.arith.CmpIOp(flir.arith.CmpIPredicate.ult, row, num_rows).result
+)
+if_op = IfOp(row_ok)
+with if_op:
+    # load and store only if row is valid
+```
+
+### Cooperative transposed store (for V^T in LDS)
+```python
+# Load V[row, col] from global, store as V^T[col, row] in LDS
+for batch in range_constexpr(NUM_BATCHES_V):
+    row = tile_start + load_row_in_batch + batch * ROWS_PER_BATCH
+    g_idx = row * HEAD_DIM + load_col_base
+    vec = arith.as_value(vec_ext.load_op(v8f16_type, V_global, [g_idx]))
+    # Scatter-store: extract each element, store transposed
+    for e in range_constexpr(VEC_WIDTH):
+        elem = arith.as_value(vec_ext.extract(vec, static_position=[e], dynamic_position=[]))
+        col_e = load_col_base + e
+        lds_idx = col_e * VT_STRIDE + (load_row_in_batch + batch * ROWS_PER_BATCH)
+        _memref.StoreOp(elem, lds_kv, [lds_idx])
+```
+
+---
+
+## 4. Online Softmax with Warp Shuffle
+
+### Per-row max and sum across BLOCK_N positions (16 or 32 wide)
+
+For `mfma_16x16x16f16`, each output row is owned by threads within the same b-group
+(lanes b*16..b*16+15). So 16-wide reduction stays within 16 consecutive lanes.
+
+### XOR shuffle pattern for 16-wide reduction
+```python
+SHUFFLE_OFFSETS = [8, 4, 2, 1]  # log2(16) = 4 steps
+
+def warp_reduce_max_16(val):
+    """Reduce max across 16 lanes within b-group."""
+    result = val
+    for offset in SHUFFLE_OFFSETS:
+        other = ds_swizzle(result, offset)  # XOR shuffle
+        result = max(result, other)
+    return result
+```
+
+### FlyDSL implementation
+```python
+from flydsl.dialects.ext.rocdl import ds_swizzle_val
+
+def reduce_max_16(val_v):
+    """val_v is v4f32 — reduce max across 4 elements, then across 16 lanes."""
+    # First reduce within v4f32 (4 row elements per thread)
+    m = vec_ext.extract(val_v, static_position=[0], ...)
+    for i in [1, 2, 3]:
+        ei = vec_ext.extract(val_v, static_position=[i], ...)
+        m = arith.maximumf(m, ei)
+    # Then reduce across 16 lanes
+    for offset in [8, 4, 2, 1]:
+        swizzle_pattern = offset | (0x1F << 5) | (0x1F << 10)
+        other = ds_swizzle_val(m, swizzle_pattern)
+        m = arith.maximumf(m, other)
+    return m
+```
+
+### Softmax update with running max (online softmax)
+```python
+# For each KV tile iteration:
+# 1. Compute S = Q @ K^T (get s_acc as v4f32)
+# 2. Row max of S tile
+m_new = reduce_max_16(s_acc)
+m_cur = arith.maximumf(m_old, m_new)
+
+# 3. Rescale previous: correction = exp(m_old - m_cur)
+correction = exp2f((m_old - m_cur) * LOG2E)
+l_new = l_old * correction
+
+# 4. Compute P = exp(S - m_cur), accumulate l_new += sum(P)
+# 5. Rescale output: o_acc *= correction, then o_acc += P @ V
+```
+
+### BLOCK_N=32: Two-part softmax
+When BLOCK_N=32, Q@K^T produces two v4f32 accumulators (lo: cols 0-15, hi: cols 16-31):
+```python
+# Separate lo/hi max
+m_lo = reduce_max_16(s_accs[0])  # max over cols 0-15
+m_hi = reduce_max_16(s_accs[1])  # max over cols 16-31
+m_new = arith.maximumf(m_lo, m_hi)  # combined max
+# Then apply softmax with combined max to both halves
+```
+
+---
+
+## 5. P@V GEMM Pattern
+
+### Intermediate result P (softmax output) as A-operand for P@V
+
+P is [BLOCK_M_PER_WAVE, BLOCK_N] in f16. Must be stored in LDS in A-operand format.
+
+### Store P to LDS (from v4f32 softmax output)
+```python
+P_STRIDE = BLOCK_N  # or BLOCK_N + PAD for bank-conflict-free
+
+# P is in s_acc (v4f32), need to convert to f16 and store row-major
+# Thread lane owns rows [b*4+0..b*4+3] at column n
+for ii in range(4):
+    p_val_f32 = vec_ext.extract(p_v4f16_or_f32, ...)
+    p_val_f16 = arith.truncf(p_val_f32, F16Type)
+    row = wave_p_offset + b * 4 + ii
+    col = n
+    lds_idx = row * P_STRIDE + col
+    _memref.StoreOp(p_val_f16, lds_p, [lds_idx])
+
+# For BLOCK_N=32: store lo half at cols 0..15, hi half at cols 16..31
+```
+
+### Reload P as A-operand for P@V MFMA
+```python
+# A-operand: need P[n, b*4:b*4+4] — row n, 4 consecutive cols
+p_lds_idx = (
+    arith.ArithValue(lane_mod_16) * P_STRIDE   # row = n
+    + ds * 16                                    # K-step within P
+    + arith.ArithValue(lane_div_16) * 4          # col = b*4
+).value
+p_pack = arith.as_value(vec_ext.load_op(v4f16_type, lds_p, [p_lds_idx]))
+```
+
+### BLOCK_N=32 P@V: Split K dimension
+P is [16, 32], V^T is [32, HD]. Split K=32 into two K=16 steps:
+```python
+for ds in range_constexpr(K_STEPS):  # K_STEPS = HD/16
+    # P_lo[16,16] @ V_top[16, ds*16:ds*16+16]
+    p_lo_pack = load_p_a_operand(col_offset=0, ds_k=0)
+    v_top_pack = load_v_b_operand(ds=ds, row_offset=0)
+    o_accs[ds] = mfma(p_lo_pack, v_top_pack, o_accs[ds])
+
+    # P_hi[16,16] @ V_bot[16, ds*16:ds*16+16]
+    p_hi_pack = load_p_a_operand(col_offset=16, ds_k=1)
+    v_bot_pack = load_v_b_operand(ds=ds, row_offset=16)
+    o_accs[ds] = mfma(p_hi_pack, v_bot_pack, o_accs[ds])
+```
+
+---
+
+## 6. Causal Masking Patterns
+
+### Causal early-exit (tile-level)
+Skip entire KV tiles beyond the causal boundary:
+```python
+# q_start = tile_idx * BLOCK_M
+# Last Q row in this tile = q_start + BLOCK_M - 1
+# Only need KV positions 0 .. q_start + BLOCK_M - 1
+if CAUSAL:
+    kv_upper = (arith.ArithValue(q_start) + BLOCK_M).value
+else:
+    kv_upper = seq_len
+
+with scf.for_(0, kv_upper, BLOCK_N, iter_args=init_args) as loop:
+```
+
+### Within-tile causal mask (for the boundary tile)
+When `kv_start + j > q_start + i`, mask S[i,j] = -inf:
+```python
+if CAUSAL:
+    # For each row ii owned by this thread:
+    q_row = q_start + wave_offset + b * 4 + ii
+    # For each col n:
+    kv_col = kv_start + n  # (or kv_start + nm*16 + n for BLOCK_N=32)
+    is_masked = kv_col > q_row
+    if is_masked:
+        s_val = -infinity
+```
+
+---
+
+## 7. Output Write-Back Pattern
+
+### Rescale and write output from accumulators
+
+After the KV loop completes, output accumulators need final rescaling by `1/l`:
+```python
+# o_accs[ds] is v4f32 for ds in range(K_STEPS)
+# l_final is the softmax denominator (f32, broadcast across 16 lanes)
+
+for ds in range_constexpr(K_STEPS):
+    # Rescale: o_accs[ds] /= l_final
+    inv_l = arith.divf(c_one_f, l_final)
+    inv_l_vec = vec_ext.broadcast(v4f32_type, inv_l)
+    o_scaled = arith.mulf(o_accs[ds], inv_l_vec)
+
+    # Convert f32 → f16
+    o_f16 = arith.truncf(o_scaled, v4f16_type)
+
+    # Write to global: thread owns O[b*4+ii, ds*16 + ...] for ii=0..3
+    # Store as v4f16 (4 consecutive output elements per thread)
+    for ii in range(4):
+        o_row = q_start + wave_offset + b * 4 + ii
+        o_col = ds * 16 + n  # but need to handle 4-element packing
+        g_idx = (batch * S * H * D) + (o_row * H * D) + (head * D) + (ds * 16 + b * 4)
+        # Store individual f16 elements or use vectorized store
+```
+
+---
+
+## 8. Q-from-Global Memory Pattern (V4.3)
+
+### Problem: LDS overlay for Q is unreliable
+LLVM AMDGPU scheduler reorders `ds_read` past `s_barrier`, breaking read/write phase separation.
+**Solution**: Load Q directly from global memory into MFMA registers, bypassing LDS entirely.
+
+### Thread-to-Q mapping for `mfma_f32_16x16x16f16`
+Each lane needs Q[n, b*4:b*4+4] as A-operand (v4f16):
+```python
+# q_row = which Q row this lane reads from
+q_row = (
+    arith.ArithValue(q_start)      # tile start
+    + arith.ArithValue(wave_q_offset)  # wave's row offset within tile
+    + arith.ArithValue(lane_mod_16)    # n = lane % 16
+).value
+
+# Pre-load all K_STEPS Q packs before KV loop
+q_a_packs = []
+for ks in range_constexpr(K_STEPS):
+    q_col = flir.const_index(ks * 16 + 0)
+    q_col = (arith.ArithValue(q_col) + arith.ArithValue(lane_div_16) * 4).value
+    g_idx = global_idx(q_row, q_col)  # q_row * HEAD_DIM + q_col
+    q_a_packs.append(arith.as_value(
+        vec_ext.load_op(v4f16_type, Q, [g_idx])
+    ))
+```
+
+### Memory access pattern
+- 4 threads with same `lane_mod_16` (different `b` values) access same row, adjacent 8-byte chunks
+- Partially coalesced: 4×8=32 bytes per group of 4 threads
+- Each wave issues K_STEPS × 64 loads (e.g., 8 × 64 = 512 loads for HD=128)
+
+### LDS savings
+- V4.2: lds_q (BLOCK_M × K_STRIDE × 2 bytes) + lds_kv + lds_p = ~23KB
+- V4.3: lds_kv + lds_p = ~12.5KB (Q eliminated entirely)
+
+---
+
+## 9. K/V Double-Buffering Pattern (from MI350 FMHA Design)
+
+### Concept: Ping-pong K/V in LDS
+Allocate 2× LDS for K/V tiles. While computing GEMM on buffer A, prefetch next K/V into buffer B.
+
+```
+Init: Load K[0]→buf_A, Load V[0]→buf_A, Load K[1]→buf_B
+Loop iteration i:
+  Compute: GEMM1(Q, K[buf_i%2]) → S → softmax → P
+  Prefetch: Load V[i]→buf_{(i+1)%2}, Load K[i+1]→buf_{(i+1)%2}
+  Compute: GEMM2(P, V[buf_i%2]) → O
+```
+
+### LDS budget
+```python
+# Each buffer: K[BLOCK_N, HD] + V^T[HD, BLOCK_N] (or combined KV region)
+LDS_PER_BUFFER = BLOCK_N * K_STRIDE + HEAD_DIM * VT_STRIDE  # in f16 elements
+LDS_TOTAL = 2 * LDS_PER_BUFFER * 2  # 2 buffers × 2 bytes/f16
+# For BN=32, HD=128, K_STRIDE=130, VT_STRIDE=34:
+# = 2 * (32*130 + 128*34) * 2 = 2 * (4160+4352) * 2 = 34048 bytes (~33KB)
+```
+
+### Key: No barrier between compute and prefetch
+The prefetch into buffer B doesn't conflict with reads from buffer A.
+Only need barrier when SWITCHING buffers (before next iteration's compute phase).
+
+---
+
+## 10. S/P Ping-Pong in VGPRs (from MI350 FMHA Design)
+
+### Problem: P→LDS→VGPR roundtrip
+Current V4.x stores P to LDS after softmax, then reloads as A-operand for GEMM2. Costs ~2 barriers + LDS traffic.
+
+### Solution: Keep P in VGPRs with transposed GEMM ordering
+Use **K^T × Q^T** (not Q × K^T) for GEMM1 so the result S is already in A-operand format for GEMM2.
+
+```
+GEMM1: S = K^T[HD, BN] × Q^T[BM, HD] → S[BN, BM]  (S in accumulator = A-operand layout)
+Softmax: S → P  (in-place, stays in VGPRs)
+GEMM2: O += V^T[HD, BN] × P[BN, BM] → O[HD, BM]   (P directly used as B-operand)
+```
+
+### VGPR cost for S/P ping-pong
+Need 2× S/P storage: current iteration's S (being computed) + previous iteration's P (being consumed by GEMM2).
+```
+SP_VGPRs = 2 * (BLOCK_N/16) * 4 * (BLOCK_M_PER_WAVE/16) = 2 * 2 * 4 * 1 = 16 VGPRs (BN=32, BM_wave=16)
+```
+
+---
+
+## 11. XDL || Softmax Co-Execution Pipeline (from MI350 FMHA Design)
+
+### Concept
+On GFX942+, MFMA (XDL unit) and VALU can execute simultaneously. Interleave:
+- GEMM2 MFMA instructions (XDL) with softmax VALU from current iteration
+- GEMM1 MFMA instructions (XDL) with output rescaling VALU from previous iteration
+
+### Pipeline structure (per iteration)
+```
+Phase 1: XDL=GEMM1(K^T×Q^T→S)   || VALU=rescale_output(prev correction)
+Phase 2: XDL=GEMM2(V^T×P_prev)  || VALU=softmax(S→P_curr)
+```
+
+### Requirements
+- S/P ping-pong (Section 10) — so current softmax doesn't conflict with GEMM2 input
+- Careful instruction interleaving in generated code (alternate MFMA and VALU instructions)
+
+---
+
+## 12. LLVM Scheduler Pitfalls
+
+### LLVM reorders LDS reads past barriers
+**Confirmed behavior**: The LLVM AMDGPU instruction scheduler can move `ds_read` (LDS read) instructions past `s_barrier` synchronization points. This was confirmed by comparing:
+- MLIR IR stage 07 (gpu-kernel-outlining): barrier1 → Q reads → barrier2 → scf.for (correct)
+- Final ISA: barrier1 → barrier2 → Q reads → K writes (broken — no barrier between Q reads and K writes)
+
+### Workarounds that DON'T work
+- `rocdl.s_waitcnt(0)` before barrier — LLVM ignores it as scheduling fence
+- Multiple barriers in sequence — LLVM coalesces/reorders around them
+
+### What DOES work
+- Eliminate the need for ordering: don't overlay LDS regions that need read-before-write protection
+- Use separate LDS allocations (no overlap) + standard barriers
+- Q-from-global (bypass LDS entirely for read-once data)
+
+---
+
+## 13. Common FlyDSL Pitfalls
+
+### ArithValue wrapping
+- `scf.for_` inner_iter_args and induction_variable return ArithValue wrappers
+- Always unwrap: `arith.as_value(loop.inner_iter_args[i])`, `arith.as_value(loop.induction_variable)`
+- `vec_ext.load_op()` returns ArithValue → unwrap before passing to `rocdl.mfma_*`
+- `vec_ext.broadcast()` returns ArithValue → unwrap before `arith.mulf`
+
+### range vs range_constexpr
+- Inside `@flir.kernel` bodies, `range_constexpr()` unrolls at compile time (required for static indexing)
+- Plain `range()` generates `scf.for` IR loops (dynamic, has overhead)
+- Use `range_constexpr()` for MFMA loops, K_STEPS, VEC_WIDTH iterations
+
+### scf.for_ iter_args pattern
+```python
+init_args = [val1, val2, ...]
+with scf.for_(lb, ub, step, iter_args=init_args) as loop:
+    # Unwrap
+    a = arith.as_value(loop.inner_iter_args[0])
+    b = arith.as_value(loop.inner_iter_args[1])
+    # ... compute new_a, new_b ...
+    scf.yield_([new_a, new_b])
+# After loop:
+result_a = arith.as_value(loop.results[0])
+result_b = arith.as_value(loop.results[1])
+```
+
+### Don't nest MLIR op constructors
+```python
+# BAD: nested constructors may fail
+result = arith.mulf(vec_ext.broadcast(...), some_val)
+
+# GOOD: unwrap intermediate results
+broadcast_val = arith.as_value(vec_ext.broadcast(...))
+result = arith.mulf(broadcast_val, some_val)
+```
+
+---
+
+## 14. Resource Budget (MI300X / GFX942)
+
+| Resource | Per CU | Per SIMD (4/CU) | For 2 waves | For 4 waves |
+|----------|--------|-----------------|-------------|-------------|
+| LDS | 64 KB | 16 KB | 32 KB/wg | 16 KB/wg |
+| Arch VGPRs | 512 | 512 | 256/wave | 128/wave |
+| Accum VGPRs | 512 | 512 | 256/wave | 128/wave |
+| SGPRs | 800 | — | 400/wave | 200/wave |
+
+### Flash Attention V4.x resource usage
+| Version | arch_vgpr | accum_vgpr | sgpr | LDS | Waves/SIMD |
+|---------|-----------|------------|------|-----|------------|
+| V4.2 | 120 | 56 | 112 | 23040 B | 2 (LDS-limited) |
+| V4.3 | 124 | 0 | ~112 | 12800 B | 4 (VGPR-limited) |
+
+- V4.3 reduced LDS below 16KB threshold but VGPR count (124) still limits to 4 waves
+- No AGPRs used (LLVM allocates all accumulators in arch VGPRs)
+- To use AGPRs: need HipKittens-style inline assembly (not available from MLIR path)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ For the test folder organization, see `tests/` (`mlir/`, `pyir/`, `kernels/`).
   - Add MLIR build lib dir to the loader path:
     - `export LD_LIBRARY_PATH=$MLIR_PATH/lib:$LD_LIBRARY_PATH`
 
+## Documentation
+
+| **Topic** | **Description** | **Guide** |
+|---|---|---|
+| Architecture | Compilation pipeline, project structure, environment config | [Architecture Guide](docs/architecture_guide.md) |
+| Layout System | FLIR layout algebra — Shape, Stride, Layout, Coord, all operations | [Layout Guide](docs/layout_system_guide.md) |
+| Kernel Authoring | Writing GPU kernels — MlirModule, tiled copies, MFMA, shared memory | [Kernel Guide](docs/kernel_authoring_guide.md) |
+| Pre-built Kernels | Available kernels — GEMM, MoE, Softmax, Norm — config and usage | [Kernels Reference](docs/prebuilt_kernels_guide.md) |
+| Testing & Benchmarks | Test infrastructure, benchmarking, performance comparison | [Testing Guide](docs/testing_benchmarking_guide.md) |
+| CuteDSL → FlyDSL | Porting from NVIDIA CuteDSL to FlyDSL — concept mapping, code examples | [Porting Guide](docs/cutedsl_to_flydsl_porting_guide.md) |
+
 ## 📐 FLIR Layout System
 
 > FLIR = **F**lexible **L**ayout **I**ntermediate **R**epresentation.

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -1,0 +1,353 @@
+# Architecture & Compilation Pipeline Guide
+
+> FlyDSL project structure, compilation stages, key abstractions, and configuration.
+
+## Quick Reference
+
+| Component | Description | Key File |
+|---|---|---|
+| **FlyDSL** | Python DSL front-end for authoring GPU kernels | `flydsl/src/flydsl/` |
+| **FLIR** | Flexible Layout IR -- MLIR dialect with layout algebra | `flir/` |
+| **Compiler** | `flir.compile()` -- end-to-end DSL-to-binary pipeline | `flydsl/src/flydsl/compiler/compiler.py` |
+| **Pipeline** | Fluent pass-pipeline builder | `flydsl/src/flydsl/compiler/pipeline.py` |
+| **Executor** | MLIR ExecutionEngine wrapper for JIT execution | `flydsl/src/flydsl/compiler/executor.py` |
+| **MlirModule** | Base class for kernel module authoring | `flydsl/src/flydsl/lang/ir/module.py` |
+
+---
+
+## 1. Project Structure
+
+```
+FlyDSL/
+├── flir/                          # C++ MLIR dialect + compiler infrastructure
+│   ├── include/flir/
+│   │   ├── FlirOps.td             # FLIR layout ops (make_shape, crd2idx, composition, ...)
+│   │   ├── FlirTypeDefs.td        # Custom types (!flir.shape, !flir.layout, ...)
+│   │   ├── FlirAttrDefs.td        # Attributes (#flir.underscore, #flir.dync_i32)
+│   │   ├── FlirPasses.td          # Pass declarations (flir-to-standard, trivial-dce)
+│   │   ├── FlirRocmOps.td         # ROCm ops (MFMA, LDS, copy, barriers)
+│   │   └── FlirRocmDialect.td     # ROCm dialect declaration
+│   ├── lib/Dialect/
+│   │   ├── Flir/
+│   │   │   ├── FlirOps.cpp        # Op verifiers and builders
+│   │   │   ├── FlirLayoutAlgebra.cpp  # Type inference for composition/product/divide
+│   │   │   └── FlirDialect.cpp    # Dialect registration
+│   │   └── FlirRocm/              # ROCm dialect implementation
+│   ├── lib/Transforms/
+│   │   ├── FlirToStandard.cpp     # flir-to-standard lowering pass
+│   │   └── FlirDCE.cpp            # trivial-dce pass
+│   ├── python_bindings/           # Python ↔ C++ bridge
+│   │   ├── dialects/flir.py       # Low-level Python bindings for FLIR ops
+│   │   └── FlirRegisterPasses.cpp # Register passes and dialects from Python
+│   ├── tools/flir-opt/            # CLI tool for running passes on .mlir files
+│   └── build.sh                   # Build script (CMake + ninja)
+│
+├── flydsl/                        # Python package (src layout)
+│   └── src/flydsl/
+│       ├── compiler/
+│       │   ├── compiler.py        # flir.compile() -- top-level compilation entry
+│       │   ├── pipeline.py        # Pipeline fluent API
+│       │   ├── executor.py        # ExecutionEngineExecutor (JIT runner)
+│       │   ├── context.py         # RAIIMLIRContext, RAIIMLIRContextModule
+│       │   ├── cache.py           # On-disk compilation cache
+│       │   └── flir_opt_helper.py # Helper for invoking flir-opt
+│       ├── dialects/ext/
+│       │   ├── flir.py            # High-level Python API for layout algebra
+│       │   ├── gpu.py             # GPU dialect extensions (launch, barrier, ...)
+│       │   ├── rocm.py            # ROCm dialect Python helpers
+│       │   ├── arith.py           # Arithmetic extensions
+│       │   └── ...                # scf, memref, vector, func, rocdl, ...
+│       ├── lang/ir/
+│       │   ├── module.py          # MlirModule base class, @kernel / @jit decorators
+│       │   └── types.py           # Type helpers
+│       ├── runtime/
+│       │   └── device.py          # get_rocm_arch() -- GPU architecture detection
+│       └── utils/
+│           └── smem_allocator.py  # SmemAllocator for LDS management
+│
+├── kernels/                       # Pre-built GPU kernels
+│   ├── preshuffle_gemm.py         # GEMM with B-preshuffle
+│   ├── mixed_preshuffle_gemm.py   # Mixed-precision GEMM (FP4/FP8)
+│   ├── moe_gemm_2stage.py         # MoE GEMM (2-stage)
+│   ├── mixed_moe_gemm_2stage.py   # Mixed MoE GEMM
+│   ├── layernorm_kernel.py        # LayerNorm
+│   ├── rmsnorm_kernel.py          # RMSNorm
+│   ├── softmax_kernel.py          # Softmax
+│   ├── reduce.py                  # Warp/block reduction primitives
+│   ├── mfma_epilogues.py          # MFMA result writeback patterns
+│   └── mfma_preshuffle_pipeline.py # Preshuffle helpers for MFMA kernels
+│
+├── tests/
+│   ├── pyir/                      # Python IR tests (no GPU required)
+│   ├── kernels/                   # GPU kernel tests + benchmarks
+│   └── test_common.py             # Shared test utilities
+│
+└── scripts/                       # Build and test helpers
+    ├── build_llvm.sh              # Build MLIR from ROCm llvm-project
+    ├── run_tests.sh               # Run all tests
+    └── run_benchmark.sh           # Run benchmarks
+```
+
+---
+
+## 2. Compilation Pipeline
+
+### 2.1 High-Level Flow
+
+```
+Python DSL (@kernel / @jit)
+        │
+        ▼
+   MLIR Module (FLIR dialect ops)
+        │
+        ▼  flir.compile()
+   ┌────────────────────────────────────────────┐
+   │  flir-to-standard                          │  FLIR → scf + arith + memref
+   │  trivial-dce                               │  Dead code elimination
+   │  canonicalize                              │  Standard MLIR canonicalization
+   │  cse                                       │  Common subexpression elimination
+   │  gpu-kernel-outlining                      │  Outline GPU kernels
+   │  gpu.module(convert-scf-to-cf)             │  SCF → ControlFlow (inside gpu.module)
+   │  gpu.module(convert-gpu-to-rocdl)          │  GPU → ROCDL (inside gpu.module)
+   │  gpu.module(reconcile-unrealized-casts)    │  Clean up casts
+   │  rocdl-attach-target{chip=gfxNNN}          │  Attach ROCm target
+   │  gpu-to-llvm                               │  GPU types → LLVM types
+   │  reconcile-unrealized-casts                │  Clean up remaining casts
+   │  gpu-module-to-binary{format=fatbin}       │  Emit HSACO binary
+   └────────────────────────────────────────────┘
+        │
+        ▼
+   ExecutionEngineExecutor (JIT runner)
+```
+
+### 2.2 Pipeline Stages in Detail
+
+The pipeline is defined in `compiler/compiler.py:_pipeline_fragments()`:
+
+| Stage | Pass | Description |
+|---|---|---|
+| 1 | `flir-to-standard` | Lowers all `flir.*` ops to standard MLIR (scf, arith, memref). Coordinate mapping (`crd2idx`, `idx2crd`) becomes arithmetic. Layout algebra ops are folded/lowered. |
+| 2 | `trivial-dce` | Removes trivially dead ops (no side effects, unused results). |
+| 3 | `canonicalize` | Standard MLIR canonicalization (constant folding, identity removal, etc.). |
+| 4 | `cse` | Common subexpression elimination. |
+| 5 | `gpu-kernel-outlining` | Moves GPU kernel bodies into `gpu.func` inside `gpu.module`. |
+| 6 | `convert-scf-to-cf` | Lowers `scf.for`/`scf.if` to `cf.br`/`cf.cond_br` (inside `gpu.module`). |
+| 7 | `convert-gpu-to-rocdl` | Converts `gpu.thread_id`, `gpu.block_id`, etc. to ROCDL intrinsics (inside `gpu.module`). |
+| 8 | `reconcile-unrealized-casts` | Cleans up unrealized conversion casts inside `gpu.module`. |
+| 9 | `rocdl-attach-target` | Attaches `#rocdl.target<chip=gfxNNN>` for the target GPU. |
+| 10 | `gpu-to-llvm` | Converts GPU-related types/ops to LLVM dialect (host-side launch infrastructure). |
+| 11 | `reconcile-unrealized-casts` | Final cast cleanup. |
+| 12 | `gpu-module-to-binary` | Compiles the GPU module to HSACO binary (embedded in the module as a blob). |
+
+### 2.3 Using the Pipeline API
+
+The `Pipeline` class provides a fluent builder:
+
+```python
+from flydsl.compiler.pipeline import Pipeline
+
+pipeline = (
+    Pipeline()
+    .flir_to_standard()
+    .canonicalize()
+    .cse()
+    .rocdl_attach_target(chip="gfx942")
+    .Gpu(Pipeline().convert_gpu_to_rocdl(runtime="HIP"))
+    .gpu_to_llvm()
+    .lower_to_llvm()
+    .gpu_module_to_binary(format="bin")
+)
+
+# Run pipeline on a module
+result = pipeline.run(module)
+
+# Or use the string representation
+print(pipeline)  # builtin.module(flir-to-standard,canonicalize,...)
+```
+
+Key `Pipeline` methods:
+- **FLIR passes**: `.flir_to_standard()`, `.flir_coord_lowering()` (alias)
+- **Optimization**: `.canonicalize()`, `.cse()`, `.inline()`, `.symbol_dce()`, `.sccp()`
+- **Conversion**: `.convert_scf_to_cf()`, `.convert_gpu_to_rocdl()`, `.gpu_to_llvm()`, `.lower_to_llvm()`
+- **Target**: `.rocdl_attach_target(chip=...)`, `.gpu_module_to_binary(format=...)`
+- **Nesting**: `.Gpu(nested_pipeline)`, `.Func(nested_pipeline)`, `.Module(nested_pipeline)`
+- **Composition**: `pipeline_a + pipeline_b`, `pipeline_a += pipeline_b`
+
+### 2.4 Using `flir.compile()`
+
+For most use cases, the high-level `flir.compile()` handles the full pipeline:
+
+```python
+from flydsl.compiler.compiler import compile
+
+# Compile and get an executor
+executor = compile(my_module, opt_level=3)
+
+# Call a kernel function
+executor.my_kernel(A, B, C)
+```
+
+`flir.compile()` automatically:
+1. Detects the target GPU architecture (or reads `ARCH` env var)
+2. Overrides `gpu.module` targets consistently
+3. Checks the on-disk cache (can skip recompilation)
+4. Runs the full pipeline
+5. Returns an `ExecutionEngineExecutor` (or `None` if `COMPILE_ONLY=1`)
+
+---
+
+## 3. Key Abstractions
+
+### 3.1 `RAIIMLIRContextModule`
+
+Sets up an MLIR context with FLIR dialects registered, a default location, a module, and an insertion point:
+
+```python
+from flydsl.compiler.context import RAIIMLIRContextModule
+
+ctx = RAIIMLIRContextModule(allow_unregistered_dialects=True)
+# ctx.context  -- MLIR Context
+# ctx.module   -- MLIR Module
+# ctx.location -- Default Location
+```
+
+### 3.2 `MlirModule`
+
+Base class for structured kernel authoring. Subclass it, define `@kernel` and `@jit` methods:
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir
+
+class MyKernels(MlirModule):
+    GPU_MODULE_NAME = "my_kernels"
+
+    @kernel
+    def my_kernel(self, A: T.memref(1024, T.f32())):
+        tid = flir.thread_idx("x")
+        # ... kernel body ...
+
+# Instantiate to emit MLIR
+mod = MyKernels()
+print(mod.module)  # prints MLIR
+```
+
+Key class attributes:
+- `GPU_MODULE_NAME` -- name for the `gpu.module` container
+- `GPU_MODULE_TARGETS` -- optional target list (overridden by `flir.compile()`)
+- `ALLOW_UNREGISTERED_DIALECTS` -- default `True`
+
+Key decorators:
+- `@kernel` -- emits a `gpu.func` with `gpu.kernel` attribute, enables range-loop lowering
+- `@jit` -- emits a host-side `func.func` with `llvm.emit_c_interface`
+
+### 3.3 `ExecutionEngineExecutor`
+
+Wraps MLIR's `ExecutionEngine` for JIT execution:
+
+```python
+executor = compile(mod)
+# Dynamic attribute lookup → calls compiled function
+executor.my_kernel(tensor_a, tensor_b)
+```
+
+Features:
+- Automatically resolves `_mlir_ciface_*` symbols
+- Supports PyTorch tensors as arguments (auto-expands to memref descriptor)
+- Handles both flattened and packed calling conventions
+
+### 3.4 `Pipeline`
+
+Fluent pass-pipeline builder (see Section 2.3).
+
+### 3.5 `FileCache`
+
+On-disk compilation cache (inspired by Triton):
+
+- Cache key: SHA-256 of `(chip, pipeline, input_sha256, flydsl version, git commit, python version, soabi, platform)`
+- Storage: `$FLIR_CACHE_DIR` or `$XDG_CACHE_HOME/flydsl/<key>/` (default: `~/.cache/flydsl/<key>/`)
+- Atomic writes with file locking
+- Controlled by environment variables (see Section 4)
+
+---
+
+## 4. Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `COMPILE_ONLY` | `0` | If `1`, compile without creating an executor. Returns `None`. |
+| `FLIR_DUMP_IR` | `0` | If `1`, dump intermediate IR at each pipeline stage. |
+| `FLIR_DUMP_DIR` | `my_ir_dumps` | Directory for IR dumps when `FLIR_DUMP_IR=1`. |
+| `ARCH` | auto-detect | Override target GPU architecture (e.g., `gfx942`, `gfx950`). |
+| `FLIR_CHIP` | -- | Alternative to `ARCH` for target chip (checked by `get_rocm_arch()`). |
+| `FLIR_GPU_ARCH` | -- | Alternative to `ARCH` for target chip (checked by `get_rocm_arch()`). |
+| `FLIR_CACHE_DIR` | `~/.cache/flydsl` | Override compilation cache directory. |
+| `FLIR_NO_CACHE` | `0` | If `1`, disable compilation caching. |
+| `FLIR_CACHE_DISABLE` | `0` | Alternative to `FLIR_NO_CACHE`. |
+| `FLIR_REBUILD` | `0` | If `1`, force recompilation (ignore cache). |
+| `FLIR_CACHE_REBUILD` | `0` | Alternative to `FLIR_REBUILD`. |
+
+### Architecture Detection Priority
+
+`get_rocm_arch()` in `runtime/device.py` checks in order:
+1. `FLIR_CHIP` env var
+2. `FLIR_GPU_ARCH` env var
+3. `HSA_OVERRIDE_GFX_VERSION` env var (supports `9.4.2` → `gfx942` format)
+4. PyTorch `torch.cuda.get_device_properties().gcnArchName`
+5. Default: `gfx942`
+
+---
+
+## 5. Target Hardware
+
+| Architecture | GPU | LDS per CU | Notes |
+|---|---|---|---|
+| `gfx942` | MI300A / MI300X | 64 KB | CDNA 3, primary development target |
+| `gfx950` | MI350 | 160 KB | CDNA 4, larger LDS |
+| `gfx90a` | MI250X | 64 KB | CDNA 2 (verified platform) |
+
+---
+
+## 6. IR Dump Workflow
+
+Enable with `FLIR_DUMP_IR=1`:
+
+```bash
+FLIR_DUMP_IR=1 FLIR_DUMP_DIR=./dumps python test_my_kernel.py
+```
+
+Produces numbered `.mlir` files:
+```
+dumps/my_kernel/
+├── 00_target_overridden.mlir
+├── 03_flir_to_standard.mlir
+├── 04_trivial_dce.mlir
+├── 05_canonicalize.mlir
+├── 06_cse.mlir
+├── 07_gpu_kernel_outlining.mlir
+├── 08_convert_scf_to_cf.mlir
+├── 09_convert_gpu_to_rocdl.mlir
+├── 10_reconcile_unrealized_casts.mlir
+├── 11_rocdl_attach_target.mlir
+├── 12_gpu_to_llvm.mlir
+├── 13_reconcile_unrealized_casts.mlir
+├── 14_gpu_module_to_binary.mlir
+└── 15_final_isa.s                  # AMD ISA assembly (best-effort)
+```
+
+---
+
+## 7. Source Files
+
+| File | Description |
+|---|---|
+| `flydsl/src/flydsl/compiler/compiler.py` | `flir.compile()` entry point, pipeline construction, IR dump logic |
+| `flydsl/src/flydsl/compiler/pipeline.py` | `Pipeline` fluent API, `run_pipeline()`, `lower_flir_to_standard()` |
+| `flydsl/src/flydsl/compiler/executor.py` | `ExecutionEngineExecutor`, shared library resolution |
+| `flydsl/src/flydsl/compiler/context.py` | `RAIIMLIRContext`, `RAIIMLIRContextModule`, dialect registration |
+| `flydsl/src/flydsl/compiler/cache.py` | `FileCache`, `make_cache_key()`, cache env var handling |
+| `flydsl/src/flydsl/runtime/device.py` | `get_rocm_arch()` GPU detection |
+| `flydsl/src/flydsl/lang/ir/module.py` | `MlirModule`, `@kernel`, `@jit` decorators |
+| `flir/include/flir/FlirPasses.td` | Pass declarations (flir-to-standard, trivial-dce) |
+| `flir/lib/Transforms/FlirToStandard.cpp` | FLIR → standard lowering implementation |
+| `flir/lib/Transforms/FlirDCE.cpp` | Dead code elimination implementation |

--- a/docs/cutedsl_to_flydsl_porting_guide.md
+++ b/docs/cutedsl_to_flydsl_porting_guide.md
@@ -1,0 +1,568 @@
+# CuteDSL → FlyDSL Porting Guide
+
+> Mapping concepts, APIs, and patterns from NVIDIA CuteDSL (CUTLASS Python DSL) to AMD FlyDSL (FLIR Python DSL).
+
+## Quick Reference
+
+| CuteDSL (NVIDIA) | FlyDSL (AMD) |
+|---|---|
+| `import cutlass.cute as cute` | `from flydsl.dialects.ext import flir` |
+| `@cute.jit` | `@kernel` / `@jit` (from `flydsl.lang.ir.module`) |
+| `cutlass.Constexpr[int]` | Python int literal (static at IR level) |
+| `cute.Tensor` | `flir.TensorView` |
+| `cute.make_layout(shape, stride)` | `flir.make_layout(shape, stride)` |
+| `cute.tiled_divide(layout, tiler)` | `flir.tiled_divide(layout, tiler)` |
+| `cute.gemm(tiled_mma, a, b, c)` | `flir.rocm.mfma(a, b, c)` / MFMA intrinsic |
+| `cute.copy(atom, src, dst)` | `flir.copy(atom, src, dst)` |
+| CUDA / PTX output | HIP / ROCDL / HSACO output |
+| SM80 / SM90 / SM100 | GFX942 / GFX950 / GFX90a |
+
+---
+
+## 1. Overview
+
+Both CuteDSL and FlyDSL are Python DSLs for writing high-performance GPU kernels with explicit layout control. They share a common intellectual heritage from NVIDIA's CuTe layout algebra but target different hardware:
+
+| Aspect | CuteDSL | FlyDSL |
+|---|---|---|
+| **Organization** | Part of NVIDIA CUTLASS | Standalone project |
+| **Hardware** | NVIDIA GPUs (CUDA) | AMD GPUs (ROCm/HIP) |
+| **IR backend** | CUTLASS MLIR dialects → CUDA/PTX | FLIR MLIR dialect → ROCDL → HSACO |
+| **Layout algebra** | `cutlass.cute` module | `flir` MLIR dialect + Python API |
+| **Kernel model** | `@cute.jit` decorator | `MlirModule` class + `@kernel`/`@jit` |
+| **Memory model** | GMEM → SMEM → RMEM → TMEM | GMEM → LDS → VGPR |
+| **Compilation** | Python JIT → MLIR → CUDA binary | Python → MLIR → ROCDL → HSACO binary |
+| **Wave/Warp size** | 32 threads (warp) | 64 threads (wavefront) |
+
+---
+
+## 2. Layout System Mapping
+
+The layout algebra is nearly identical between CuteDSL and FlyDSL. Both implement the same mathematical foundation from CuTe.
+
+### 2.1 Core Types
+
+| CuteDSL | FlyDSL | Notes |
+|---|---|---|
+| `cute.make_shape(M, N)` | `flir.make_shape(M, N)` | Identical semantics |
+| `cute.make_stride(s0, s1)` | `flir.make_stride(s0, s1)` | Identical semantics |
+| `cute.make_layout(shape, stride)` | `flir.make_layout(shape, stride)` | Identical semantics |
+| `cute.make_coord(i, j)` | `flir.make_coord(i, j)` | Identical semantics |
+| Python int literal | Python int literal | Both: static at compile time |
+| `cutlass.Constexpr[int]` | Python int (always static) | FlyDSL ints are static in MLIR IR |
+
+**CuteDSL:**
+```python
+import cutlass.cute as cute
+
+shape = cute.make_shape(128, 64)
+stride = cute.make_stride(1, 128)    # Column-major
+layout = cute.make_layout(shape, stride)
+coord = cute.make_coord(3, 5)
+```
+
+**FlyDSL:**
+```python
+from flydsl.dialects.ext import flir
+
+shape = flir.make_shape(128, 64)
+stride = flir.make_stride(1, 128)    # Column-major
+layout = flir.make_layout(shape, stride)
+coord = flir.make_coord(3, 5)
+```
+
+### 2.2 Query Operations
+
+| CuteDSL | FlyDSL | Formula |
+|---|---|---|
+| `cute.size(layout)` | `flir.size(layout)` | Product of shape elements |
+| `cute.cosize(layout)` | `flir.cosize(layout)` | Max index + 1 |
+| `cute.rank(layout)` | `flir.rank(layout)` | Number of modes |
+| `cute.size(layout, mode=[i])` | `flir.get(flir.get_shape(layout), i)` | Size of mode i |
+
+### 2.3 Coordinate Mapping
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.crd2idx(coord, layout)` | `flir.crd2idx(coord, layout)` | Coord → linear index |
+| `cute.idx2crd(idx, layout)` | `flir.idx2crd(idx, layout)` | Linear index → coord |
+
+Both compute `index = dot(coord, stride)`.
+
+### 2.4 Layout Algebra Operations
+
+All layout algebra operations have identical names and semantics:
+
+| Operation | CuteDSL | FlyDSL |
+|---|---|---|
+| **Composition** | `cute.composition(A, B)` | `flir.composition(A, B)` |
+| **Complement** | `cute.complement(layout, cotarget)` | `flir.complement(layout, cotarget)` |
+| **Coalesce** | `cute.coalesce(layout)` | `flir.coalesce(layout)` |
+| **Logical Product** | `cute.logical_product(A, B)` | `flir.logical_product(A, B)` |
+| **Zipped Product** | `cute.zipped_product(A, B)` | `flir.zipped_product(A, B)` |
+| **Tiled Product** | `cute.tiled_product(A, B)` | `flir.tiled_product(A, B)` |
+| **Flat Product** | `cute.flat_product(A, B)` | `flir.flat_product(A, B)` |
+| **Raked Product** | `cute.raked_product(A, B)` | `flir.raked_product(A, B)` |
+| **Blocked Product** | `cute.blocked_product(A, B)` | `flir.blocked_product(A, B)` |
+| **Logical Divide** | `cute.logical_divide(A, tiler)` | `flir.logical_divide(A, tiler)` |
+| **Zipped Divide** | `cute.zipped_divide(A, tiler)` | `flir.zipped_divide(A, tiler)` |
+| **Tiled Divide** | `cute.tiled_divide(A, tiler)` | `flir.tiled_divide(A, tiler)` |
+| **Flat Divide** | `cute.flat_divide(A, tiler)` | `flir.flat_divide(A, tiler)` |
+| **Local Partition** | `cute.local_partition(layout, ...)` | `flir.local_partition(layout, ...)` |
+| **Local Tile** | `cute.local_tile(layout, ...)` | `flir.local_tile(layout, ...)` |
+
+---
+
+## 3. Kernel Definition
+
+### 3.1 CuteDSL Pattern
+
+CuteDSL uses `@cute.jit` decorator on methods of a kernel class:
+
+```python
+import cutlass.cute as cute
+import cutlass
+
+class MyKernel:
+    def __init__(self, acc_dtype, mma_tiler_mn, ...):
+        self.acc_dtype = acc_dtype
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        ...
+
+    @cute.jit
+    def __call__(
+        self,
+        A: cute.Tensor,
+        B: cute.Tensor,
+        C: cute.Tensor,
+        M: cutlass.Constexpr[int],
+    ):
+        # Kernel body
+        ...
+```
+
+### 3.2 FlyDSL Pattern
+
+FlyDSL uses `MlirModule` subclass with `@kernel` and `@jit` decorators:
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir, arith, gpu
+import _mlir.extras.types as T
+
+class MyKernel(MlirModule):
+    GPU_MODULE_NAME = "my_kernel"
+    GPU_MODULE_TARGETS = ['#rocdl.target<chip = "gfx942">']
+
+    @kernel
+    def my_kernel(self,
+                  A: T.memref(T.dynamic(), T.f16()),
+                  B: T.memref(T.dynamic(), T.f16()),
+                  C: T.memref(T.dynamic(), T.f16()),
+                  M: T.index()):
+        # Kernel body
+        ...
+
+    @jit
+    def __call__(self, A, B, C, M, stream_ptr: T.i64()):
+        # Host-side launch wrapper
+        ...
+```
+
+**Key differences:**
+| CuteDSL | FlyDSL |
+|---|---|
+| `@cute.jit` on any method | `@kernel` for GPU function, `@jit` for host function |
+| Class is a plain Python class | Class extends `MlirModule` |
+| Parameters typed with `cute.Tensor`, `cutlass.Constexpr[int]` | Parameters typed with `T.memref(...)`, `T.index()` |
+| Compilation via CUTLASS JIT pipeline | Compilation via `flir.compile()` |
+| No explicit `GPU_MODULE_NAME` | Must set `GPU_MODULE_NAME` class attribute |
+
+---
+
+## 4. Thread and Block Hierarchy
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.arch.thread_idx()` | `flir.thread_idx("x")` | Thread index within block |
+| `cute.arch.block_idx()` | `flir.block_idx("x")` | Block index |
+| `cute.arch.block_dim()` | `flir.block_dim("x")` | Block dimension |
+| `cute.arch.cluster_idx()` | *(not applicable)* | Cluster index (SM90+) |
+
+**CuteDSL:**
+```python
+tid = cute.arch.thread_idx()
+bid = cute.arch.block_idx()
+```
+
+**FlyDSL:**
+```python
+tid = flir.thread_idx("x")
+bid = flir.block_idx("x")
+```
+
+---
+
+## 5. Tensor Creation and Memory
+
+### 5.1 Tensor Construction
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.make_tensor(ptr, layout)` | `flir.make_tensor(memref, shape, strides, ...)` | Create a tensor view |
+| `cute.make_rmem_tensor(shape, dtype)` | `flir.make_fragment_like(template)` | Register fragment |
+| `cute.Tensor` (SSA-based) | `flir.TensorView` (Python wrapper) | Tensor abstraction |
+
+**CuteDSL:**
+```python
+# Global memory tensor
+gmem_A = cute.make_tensor(global_A_ptr, cute.make_layout((M, K), (1, M)))
+
+# Register fragment
+rmem_frag = cute.make_rmem_tensor((16, 16), cute.float32)
+```
+
+**FlyDSL:**
+```python
+# Global memory tensor view
+gmem_A = flir.TensorView(
+    arg_a,                  # memref argument
+    (tile_m, tile_k),       # shape
+    strides=(1, M),         # strides
+    base_indices=(base_m,), # base offset
+    element_type=T.f16(),
+)
+
+# Register fragment
+rmem_frag = flir.make_fragment_like(template_tensor)
+```
+
+### 5.2 Memory Hierarchy
+
+| CuteDSL (NVIDIA) | FlyDSL (AMD) | Notes |
+|---|---|---|
+| Global Memory (GMEM) | Global Memory (GMEM) | Same concept |
+| Shared Memory (SMEM, 48-228 KB) | LDS (Local Data Share, 64-160 KB) | Same purpose, different name |
+| Register File (RMEM) | VGPR (Vector General Purpose Registers) | Same purpose |
+| Tensor Memory (TMEM, Blackwell) | *(not applicable)* | Blackwell-specific |
+| L2 Cache | L2 Cache | Similar |
+
+**Shared memory allocation:**
+
+**CuteDSL:**
+```python
+# Shared memory is allocated within the kernel
+smem_layout = cute.make_layout((128, 64), (1, 128))
+smem_tensor = cute.make_tensor(smem_ptr, smem_layout)
+```
+
+**FlyDSL:**
+```python
+from flydsl.utils import SmemAllocator
+
+allocator = SmemAllocator(ctx, arch="gfx942")
+lds_gen = allocator.allocate_array(T.f16(), num_elems=128*64)
+allocator.finalize()  # Inside gpu.module body
+
+# Inside kernel:
+base = allocator.get_base()
+lds_ptr = lds_gen(base)  # SmemPtr for typed access
+```
+
+### 5.3 Swizzling (Bank Conflict Avoidance)
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.Swizzle(M, B, S)` | `flir.swizzle_xor16(row, col, k_blocks)` | LDS bank conflict avoidance |
+
+CuteDSL uses parameterized `Swizzle<M,B,S>` templates. FlyDSL uses XOR16 byte-level swizzle at 16-byte granularity.
+
+**FlyDSL:**
+```python
+col_swizzled = flir.swizzle_xor16(row, col_bytes, k_blocks16)
+```
+
+---
+
+## 6. Data Movement (Copy Operations)
+
+### 6.1 Copy Atoms and Tiled Copies
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.Copy[cute.SM80_TMA[...]]()` | `flir.make_copy_atom(dtype, vector_size)` | Copy descriptor |
+| `cute.copy(atom, src, dst)` | `flir.copy(atom, src, dst)` | Execute copy |
+| *(implicit in tiled copy)* | `flir.make_tiled_copy_tv(atom, thr, val)` | Distributed copy |
+| *(via copy API)* | `tiled.get_slice(tid)` → `.partition_S(src)` / `.partition_D(dst)` | Thread-level slicing |
+
+**CuteDSL:**
+```python
+# TMA copy (Hopper/Blackwell)
+tma_copy = cute.TMA(...)
+cute.copy(tma_copy, gmem_src, smem_dst)
+
+# CpAsync copy (Ampere)
+cute.cpasync(gmem_src, smem_dst, size)
+```
+
+**FlyDSL:**
+```python
+# Create copy atom
+atom = flir.make_copy_atom(T.f16(), vector_size=8)
+
+# Create tiled copy (distributed across threads)
+thr_layout = flir.make_ordered_layout(256, 8)  # 256 threads, 8 elements each
+val_layout = flir.make_layout(flir.make_shape(1, 8), flir.make_stride(0, 1))
+tiled_copy = flir.make_tiled_copy_tv(atom, thr_layout, val_layout)
+
+# Get thread slice
+thr_copy = tiled_copy.get_slice(tid)
+src_partition = thr_copy.partition_S(src_tensor)
+dst_partition = thr_copy.partition_D(dst_tensor)
+
+# Execute copy
+flir.copy(tiled_copy, src_tensor, dst_tensor)
+```
+
+### 6.2 Buffer Loads (AMD-specific)
+
+FlyDSL provides AMD-specific buffer load intrinsics not present in CuteDSL:
+
+```python
+from flydsl.dialects.ext import buffer_ops
+
+# Buffer resource for global memory (AMD buffer load dwordx4)
+rsrc = buffer_ops.create_buffer_resource(arg_a, num_records)
+
+# Buffer load 16 bytes
+from kernels.mfma_preshuffle_pipeline import buffer_copy_gmem16_dwordx4
+vec = buffer_copy_gmem16_dwordx4(flir, arg=arg_a, elem_type=T.i8(),
+                                  idx_i32=offset, atom_g2r16=atom, rsrc=rsrc)
+```
+
+---
+
+## 7. Compute Operations (MMA / MFMA)
+
+### 7.1 Matrix Multiply
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.TiledMMA(...)` | MFMA intrinsics (see below) | Tiled matrix multiply |
+| `cute.gemm(tiled_mma, a, b, c)` | Manual MFMA loop | Matrix multiply-accumulate |
+| SM80 Tensor Cores | MFMA (Matrix Fused Multiply-Add) | Hardware MMA unit |
+| Warp-level (32 threads) | Wavefront-level (64 threads) | Cooperative MMA |
+
+**CuteDSL (SM90/SM100):**
+```python
+tiled_mma = sm100_utils.make_trivial_tiled_mma(
+    a_dtype=cute.float16,
+    a_major_mode=cute.LayoutRight,
+    b_major_mode=cute.LayoutRight,
+    acc_dtype=cute.float32,
+    cta_group=tcgen05.CtaGroup.ONE,
+    mma_shape=(128, 64),
+)
+cute.gemm(tiled_mma, a_frag, b_frag, c_accumulator)
+```
+
+**FlyDSL (GFX942/GFX950):**
+```python
+from flydsl.dialects.ext import rocdl
+
+# Direct MFMA intrinsic (16x16xK)
+# FP8: mfma_f32_16x16x32_fp8_fp8 (K=32)
+# INT8: mfma_i32_16x16x32_i8 (K=32)
+# FP16: mfma_f32_16x16x16f16 (K=16)
+c_acc = rocdl.mfma_f32_16x16x32_fp8_fp8(a_pack, b_pack, c_acc)
+
+# K64-byte micro-step pattern (2x K32 per step)
+for ku in range(tile_k_bytes // 64):
+    a_val = lds_load_pack_k32(...)   # Load A from LDS
+    b_val = load_b_pack_k32(...)     # Load B from GMEM
+    c_acc = rocdl.mfma_f32_16x16x32_fp8_fp8(a_val, b_val, c_acc)
+    # second half
+    a_val2 = lds_load_pack_k32(...)
+    b_val2 = load_b_pack_k32(...)
+    c_acc = rocdl.mfma_f32_16x16x32_fp8_fp8(a_val2, b_val2, c_acc)
+```
+
+### 7.2 MMA Instruction Mapping
+
+| CuteDSL (NVIDIA) | FlyDSL (AMD) | Sizes |
+|---|---|---|
+| `mma.sync.m16n8k16.f16` (SM80) | `mfma_f32_16x16x16f16` | M16 N16 K16 |
+| `mma.sync.m16n8k32.s8` (SM80) | `mfma_i32_16x16x32_i8` | M16 N16 K32 |
+| `tcgen05.mma` (SM100) | `mfma_f32_16x16x32_fp8_fp8` | M16 N16 K32 |
+| *(N/A)* | `mfma_scale_x128` (GFX950) | MXFP4 scaled MMA |
+
+---
+
+## 8. Synchronization
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| `cute.arch.syncthreads()` | `gpu.barrier()` | Block-level barrier |
+| `cute.arch.fence_view_async_shared()` | `gpu.barrier()` | Shared memory fence |
+| `pipeline.NamedBarrier(...)` | *(manual barrier)* | Named barriers |
+| `cute.arch.cluster_sync()` | *(not applicable)* | Cluster sync (SM90+) |
+
+**CuteDSL:**
+```python
+cute.arch.syncthreads()
+```
+
+**FlyDSL:**
+```python
+from flydsl.dialects.ext import gpu
+gpu.barrier()
+```
+
+---
+
+## 9. Compilation and Execution
+
+### 9.1 Compilation Pipeline
+
+**CuteDSL:**
+```python
+# JIT compilation is implicit via @cute.jit
+kernel = MyKernel(acc_dtype=cutlass.Float32, ...)
+kernel(A_tensor, B_tensor, C_tensor, M=M)  # First call triggers compilation
+```
+
+**FlyDSL:**
+```python
+import flydsl
+
+# Option 1: Using compile() (preferred for production)
+mod = MyKernel()
+executor = flydsl.compile(mod)
+executor(A_torch, B_torch, C_torch, M)
+
+# Option 2: Using compile_to_hsaco() (for tests)
+from tests.utils import compile_to_hsaco
+hsaco_bytes = compile_to_hsaco(mod)
+```
+
+### 9.2 Environment Variables
+
+| CuteDSL | FlyDSL | Description |
+|---|---|---|
+| *(CUDA_VISIBLE_DEVICES)* | `FLIR_CHIP` / `FLIR_GPU_ARCH` | Target architecture |
+| *(N/A)* | `FLIR_DUMP_IR=1` | Dump intermediate MLIR IR |
+| *(N/A)* | `FLIR_DUMP_DIR=/path` | IR dump location |
+| *(N/A)* | `COMPILE_ONLY=1` | Skip execution, compile only |
+| *(N/A)* | `FLIR_NO_CACHE=1` | Disable compilation cache |
+| *(N/A)* | `FLIR_TIME_COMPILE=1` | Print compilation timing |
+
+---
+
+## 10. Complete Porting Example: Vector Addition
+
+### CuteDSL Version
+
+```python
+import cutlass.cute as cute
+import cutlass
+
+class VecAddKernel:
+    @cute.jit
+    def __call__(self, A: cute.Tensor, B: cute.Tensor, C: cute.Tensor,
+                 N: cutlass.Constexpr[int]):
+        tid = cute.arch.thread_idx()
+        bid = cute.arch.block_idx()
+        idx = bid * 256 + tid
+        if idx < N:
+            C[idx] = A[idx] + B[idx]
+```
+
+### FlyDSL Version
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir, arith, gpu
+import _mlir.extras.types as T
+
+class VecAddKernel(MlirModule):
+    GPU_MODULE_NAME = "vec_add"
+
+    @kernel
+    def vec_add(self,
+                A: T.memref(T.dynamic(), T.f32()),
+                B: T.memref(T.dynamic(), T.f32()),
+                C: T.memref(T.dynamic(), T.f32()),
+                N: T.index()):
+        tid = flir.thread_idx("x")
+        bid = flir.block_idx("x")
+        block_size = arith.constant(256, index=True)
+        idx = bid * block_size + tid
+
+        # Load (via memref dialect, accessed through flir)
+        a_val = flir.memref.load(A, [idx])
+        b_val = flir.memref.load(B, [idx])
+
+        # Compute
+        c_val = arith.addf(a_val, b_val)
+
+        # Store
+        flir.memref.store(c_val, C, [idx])
+```
+
+---
+
+## 11. GEMM Porting Checklist
+
+When porting a CuteDSL GEMM to FlyDSL:
+
+1. **Replace `@cute.jit`** with `MlirModule` + `@kernel` / `@jit`
+2. **Replace `cute.Tensor`** parameters with `T.memref(...)` types
+3. **Replace `cute.make_layout()`** with `flir.make_layout()` (identical API)
+4. **Replace NVIDIA tensor cores** with AMD MFMA intrinsics:
+   - `mfma_f32_16x16x32_fp8_fp8` for FP8
+   - `mfma_i32_16x16x32_i8` for INT8
+   - `mfma_f32_16x16x16f16` for FP16
+5. **Replace SMEM allocation** with `SmemAllocator`
+6. **Replace `cute.Swizzle`** with `flir.swizzle_xor16()`
+7. **Replace TMA/CpAsync** with `buffer_ops` (AMD buffer loads)
+8. **Adjust warp size**: 32 → 64 (AMD wavefront)
+9. **Adjust shared memory limits**: Check `SMEM_CAPACITY_MAP` (gfx942=64KB, gfx950=160KB)
+10. **Replace `cute.arch.syncthreads()`** with `gpu.barrier()`
+11. **Use `flydsl.compile()`** instead of CuteDSL JIT compilation
+
+---
+
+## 12. Key Differences Summary
+
+| Aspect | CuteDSL | FlyDSL |
+|---|---|---|
+| **Language** | Python + `@cute.jit` | Python + MLIR emission |
+| **Hardware** | NVIDIA CUDA GPUs | AMD ROCm GPUs |
+| **Warp/Wave size** | 32 (warp) | 64 (wavefront) |
+| **Shared memory** | SMEM (48-228 KB) | LDS (64-160 KB) |
+| **MMA unit** | Tensor Core (HMMA/GMMA/TCGEN05) | MFMA |
+| **Global loads** | `ld.global` / TMA / CpAsync | `buffer_load_dwordx4` |
+| **Swizzle** | `Swizzle<M,B,S>` | `swizzle_xor16` |
+| **Compilation** | Python JIT → CUDA binary | Python → MLIR → HSACO |
+| **Caching** | *(managed by CUTLASS)* | `FileCache` (SHA-256 keyed) |
+| **Layout algebra** | Identical semantics | Identical semantics |
+| **IR dump** | *(via CUTLASS debug flags)* | `FLIR_DUMP_IR=1` |
+
+---
+
+## 13. Source Files
+
+### CuteDSL (reference)
+- CUTLASS GitHub: `python/cutlass/cute/` — Core CuteDSL module
+- CUTLASS GitHub: `examples/blackwell/` — Example kernels (dense GEMM, grouped GEMM, flash attention)
+- PyTorch Inductor: `torch/_inductor/codegen/cutedsl/` — CuteDSL integration in PyTorch
+- PyCute: `torch/distributed/_pycute/layout.py` — Pure-Python layout algebra reference
+
+### FlyDSL
+- `flydsl/src/flydsl/dialects/ext/flir.py` — Layout algebra Python API
+- `flydsl/src/flydsl/lang/ir/module.py` — MlirModule, @kernel, @jit
+- `flydsl/src/flydsl/compiler/compiler.py` — `flir.compile()` pipeline
+- `flydsl/src/flydsl/utils/smem_allocator.py` — SmemAllocator
+- `flydsl/src/flydsl/dialects/ext/rocm.py` — ROCm dialect helpers
+- `kernels/preshuffle_gemm.py` — GEMM implementation example
+- `tests/kernels/test_vec_add.py` — VecAdd example with full layout algebra

--- a/docs/kernel_authoring_guide.md
+++ b/docs/kernel_authoring_guide.md
@@ -1,0 +1,509 @@
+# Kernel Authoring Guide
+
+> Writing GPU kernels with FlyDSL: MlirModule, thread hierarchy, TensorView, tiled copies, MFMA, shared memory, and synchronization.
+
+## Quick Reference
+
+| Concept | API | Description |
+|---|---|---|
+| **Module** | `class MyKernel(MlirModule)` | Base class for kernel modules |
+| **Kernel** | `@kernel` decorator | Emit `gpu.func` with `gpu.kernel` attribute |
+| **Host func** | `@jit` decorator | Emit host-side `func.func` |
+| **Thread ID** | `flir.thread_idx("x")` | Get thread index in workgroup |
+| **Block ID** | `flir.block_idx("x")` | Get block/workgroup index |
+| **Block dim** | `flir.block_dim("x")` | Get block dimension size |
+| **Tensor** | `flir.make_tensor(ptr, shape, strides)` | Create a TensorView |
+| **Fragment** | `flir.make_fragment_like(template)` | Register memory buffer |
+| **Copy atom** | `flir.make_copy_atom(dtype, vec_size)` | Copy descriptor |
+| **Tiled copy** | `flir.make_tiled_copy_tv(atom, thr, val)` | Distributed copy |
+| **Copy** | `flir.copy(tiled, src, dst)` | Execute data movement |
+| **LDS** | `SmemAllocator` | Shared memory management |
+| **Barrier** | `gpu.barrier()` | Workgroup synchronization |
+| **Compile** | `compile(module)` | Full pipeline → executor |
+
+---
+
+## 1. Module Structure
+
+### 1.1 Using `MlirModule` (Structured Pattern)
+
+```python
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+from flydsl.dialects.ext import flir, arith, gpu
+import _mlir.extras.types as T
+
+class VecAddKernel(MlirModule):
+    GPU_MODULE_NAME = "vec_add"
+
+    @kernel
+    def vecAdd(self, A: T.memref(1024, T.f32()),
+                     B: T.memref(1024, T.f32()),
+                     C: T.memref(1024, T.f32())):
+        tid = flir.thread_idx("x")
+        bid = flir.block_idx("x")
+        # ... kernel body ...
+
+# Instantiate to emit MLIR
+mod = VecAddKernel()
+print(mod.module)  # view MLIR IR
+```
+
+### 1.2 Using `RAIIMLIRContextModule` (Standalone Pattern)
+
+```python
+from flydsl.compiler.context import RAIIMLIRContextModule
+from flydsl.dialects.ext import gpu, flir
+import _mlir.extras.types as T
+
+ctx = RAIIMLIRContextModule(allow_unregistered_dialects=True)
+gpu.set_container_module(ctx.module)
+
+@gpu.module("my_kernels", ["#rocdl.target<abi = \"500\">"])
+def mod():
+    pass
+
+@flir.kernel
+def my_kernel(A: T.memref(1024, T.f32())):
+    tid = flir.thread_idx("x")
+    # ... kernel body ...
+```
+
+### 1.3 `MlirModule` Class Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| `GPU_MODULE_NAME` | `"kernels"` | Name of the `gpu.module` container |
+| `GPU_MODULE_TARGETS` | `None` | Target list (overridden by `flir.compile()`) |
+| `ALLOW_UNREGISTERED_DIALECTS` | `True` | Allow unknown dialects in context |
+
+### 1.4 `init_gpu_module()` Hook
+
+Override this method in your `MlirModule` subclass to insert ops at the beginning of the `gpu.module` body (e.g., `memref.global` for shared memory):
+
+```python
+class MyKernel(MlirModule):
+    GPU_MODULE_NAME = "my_kernel"
+
+    def init_gpu_module(self):
+        # Called before any @kernel methods
+        self.smem.finalize()  # emit memref.global for LDS
+```
+
+---
+
+## 2. Thread / Block Hierarchy
+
+```python
+# Thread index within workgroup (0 to blockDim-1)
+tid_x = flir.thread_idx("x")  # returns index-typed Value
+tid_y = flir.thread_idx("y")
+tid_z = flir.thread_idx("z")
+
+# Block (workgroup) index within grid
+bid_x = flir.block_idx("x")
+bid_y = flir.block_idx("y")
+
+# Block dimensions
+bdim_x = flir.block_dim("x")
+
+# Linear thread index (common pattern)
+tid_linear = (flir.thread_idx("y") * flir.block_dim("x")
+              + flir.thread_idx("x")).value
+```
+
+---
+
+## 3. TensorView
+
+`TensorView` is the Python-side representation of a multi-dimensional memory region:
+
+```python
+# Create from memref pointer with shape and strides
+tensor_A = flir.make_tensor(A, shape=(M, N), strides=(N, 1))
+
+# Create 1D view
+tensor_flat = flir.make_tensor(ptr, shape=(N,), strides=(1,))
+```
+
+Key attributes:
+- `shape` -- tuple of dimension extents
+- `strides` -- memory strides per dimension
+- `base_indices` -- base offsets into the backing memref
+- `element_type` -- MLIR element type
+- `memref` -- backing MLIR memref value
+
+You can also construct a `TensorView` directly:
+
+```python
+view = flir.TensorView(
+    memref_value,
+    shape=(M, N),
+    strides=(N, 1),
+    base_indices=(offset_m, offset_n),
+    element_type=T.f16(),
+)
+```
+
+---
+
+## 4. Tiled Copies
+
+Tiled copies distribute data movement across threads in a workgroup.
+
+### 4.1 Copy Atom
+
+A `CopyAtom` describes a single thread's copy operation:
+
+```python
+# Copy atom: element type, vector width, coalesced flag
+copy_atom = flir.make_copy_atom(T.f32(), vector_size=8)
+copy_atom = flir.make_copy_atom(T.f16(), vector_size=16, is_coalesced=True)
+```
+
+### 4.2 Tiled Copy
+
+A `TiledCopy` distributes a copy atom across threads using thread and value layouts:
+
+```python
+THREADS = 256
+TILE = 8
+VEC = 4
+
+# Thread layout: how threads are arranged
+thr_layout = flir.make_ordered_layout((THREADS,), order=(0,))
+
+# Value layout: how many elements each thread handles
+val_layout = flir.make_ordered_layout((TILE,), order=(0,))
+
+# Create tiled copy
+tiled = flir.make_tiled_copy_tv(
+    copy_atom, thr_layout, val_layout,
+    thr_shape=(THREADS,), val_shape=(TILE,),
+)
+```
+
+### 4.3 Thread Slicing and Partitioning
+
+```python
+# Get this thread's slice of the copy
+thr_copy = tiled.get_slice(tid_linear)
+
+# Partition source and destination tensors for this thread
+thr_src = thr_copy.partition_S(src_tensor)
+thr_dst = thr_copy.partition_D(dst_tensor)
+```
+
+### 4.4 Copy Execution
+
+```python
+# Register fragment (destination buffer)
+frag = flir.make_fragment_like(thr_src, T.f32())
+
+# Execute copy: src → frag
+flir.copy(tiled, thr_src, frag)
+
+# Copy with predication (bounds checking)
+flir.copy(tiled, thr_src, frag, pred=mask)
+
+# Copy with LDS swizzle
+flir.copy(atom, src, dst,
+    dst_swizzle_xor16_kblocks=k_blocks,
+    dst_swizzle_xor16_dims=(0, 1))
+
+# Copy returning vector (for buffer loads)
+vec = flir.copy(atom, src, None,
+    return_vector=True,
+    src_buffer_resource=rsrc,
+    alignment=16)
+```
+
+---
+
+## 5. Register Fragments
+
+Fragments represent per-thread register storage:
+
+```python
+# Create fragment matching a TensorView's shape
+frag = flir.make_fragment_like(tensor_view, T.f32())
+
+# Create fragment matching a TiledCopy
+frag = flir.make_fragment_like(tiled_copy)
+
+# Create explicit register tensor
+rmem = flir.make_rmem_tensor((16, 16), T.f32())
+
+# Create identity/coordinate tensor
+identity = flir.make_identity_tensor((M, N))
+```
+
+---
+
+## 6. MFMA Operations
+
+Matrix Fused Multiply-Add instructions for AMD GPUs:
+
+### MLIR ROCm Dialect
+
+```mlir
+// Single MFMA instruction
+%d = flir.rocm.mfma %a, %b, %c {
+    shape = [32, 32, 8], arch = "gfx942"
+} : (!flir.tensor<f16, ...>, !flir.tensor<f16, ...>,
+     !flir.tensor<f32, ...>) -> !flir.tensor<f32, ...>
+
+// Tiled MFMA (multi-wavefront)
+%d = flir.rocm.tiled_mfma %a, %b, %c {
+    atom = #flir_rocm.mfma_atom<[32, 32, 8], f16, f16, f32, gfx942>,
+    tile_shape = [128, 128, 32]
+} : (...)
+```
+
+### Supported MFMA Shapes (GFX942)
+
+| Instruction | M | N | K | A Type | D Type |
+|---|---|---|---|---|---|
+| `mfma_f32_32x32x8_f16` | 32 | 32 | 8 | FP16 | FP32 |
+| `mfma_f32_16x16x16_f16` | 16 | 16 | 16 | FP16 | FP32 |
+| `mfma_f32_32x32x16_bf16` | 32 | 32 | 16 | BF16 | FP32 |
+| `mfma_f64_16x16x4_f64` | 16 | 16 | 4 | FP64 | FP64 |
+| `mfma_f32_16x16x32_f8` | 16 | 16 | 32 | FP8 | FP32 |
+| `mfma_i32_16x16x32_i8` | 16 | 16 | 32 | INT8 | INT32 |
+
+### In Python Kernel Code
+
+MFMA is typically used through the `rocdl` intrinsics after lowering, but the FLIR ROCm ops provide a structured interface during IR construction. See the GEMM kernels in `kernels/preshuffle_gemm.py` for complete examples.
+
+---
+
+## 7. Shared Memory (LDS)
+
+### 7.1 `SmemAllocator`
+
+```python
+from flydsl.utils.smem_allocator import SmemAllocator
+import _mlir.extras.types as T
+
+class MyGemmKernel(MlirModule):
+    GPU_MODULE_NAME = "gemm"
+
+    def __init__(self):
+        self.smem = SmemAllocator(None, arch="gfx942")
+        # Reserve LDS space before emitting kernels
+        self.lds_a = self.smem.allocate_array(T.f16(), 8192)
+        self.lds_b = self.smem.allocate_array(T.f16(), 8192)
+        super().__init__()
+
+    def init_gpu_module(self):
+        # Emit memref.global for the LDS buffer
+        self.smem.finalize()
+
+    @kernel
+    def gemm_kernel(self, ...):
+        # Get LDS base pointer inside kernel
+        lds_base = self.smem.get_base()
+        # Get typed views
+        lds_a_ptr = self.lds_a(lds_base)  # SmemPtr
+        lds_b_ptr = self.lds_b(lds_base)  # SmemPtr
+        # Load/store through SmemPtr
+        val = lds_a_ptr.load([idx])
+        lds_b_ptr.store(val, [idx])
+```
+
+### 7.2 `SmemAllocator` API
+
+| Method | Description |
+|---|---|
+| `allocate(size_bytes)` | Allocate raw bytes |
+| `allocate(mlir_type)` | Allocate one scalar of given type |
+| `allocate_array(dtype, num_elems)` | Allocate contiguous array |
+| `allocate_tensor(layout, element_type, swizzle=None)` | Allocate tensor with layout |
+| `finalize()` | Emit `memref.global` (call in `init_gpu_module`) |
+| `get_base()` | Get base pointer (call inside kernel) |
+
+### 7.3 LDS Capacity
+
+| Architecture | LDS per CU |
+|---|---|
+| `gfx942` (MI300X) | 64 KB |
+| `gfx950` (MI350) | 160 KB |
+
+The allocator checks capacity and raises `RuntimeError` on overflow.
+
+### 7.4 `SmemPtr`
+
+Returned by allocator generators, provides typed access to LDS regions:
+
+```python
+ptr = allocator_gen(lds_base)  # SmemPtr
+memref_view = ptr.get()        # ir.Value (memref view)
+val = ptr.load([idx])          # Load from LDS
+ptr.store(val, [idx])          # Store to LDS
+```
+
+---
+
+## 8. Synchronization
+
+```python
+from flydsl.dialects.ext import gpu
+
+# Workgroup barrier (s_barrier)
+gpu.barrier()
+```
+
+```mlir
+// MLIR
+gpu.barrier
+
+// ROCm dialect
+flir.rocm.barrier              // workgroup barrier
+flir.rocm.wavefront_barrier    // wavefront-level barrier
+```
+
+---
+
+## 9. Complete Example: VecAdd
+
+From `tests/kernels/test_vec_add.py`:
+
+```python
+from flydsl.compiler.context import RAIIMLIRContextModule
+from flydsl.compiler.compiler import compile
+from flydsl.dialects.ext import gpu, flir
+import _mlir.extras.types as T
+
+N = 20480000
+THREADS = 256
+TILE = 8
+VEC = 4
+
+# Set up MLIR context
+ctx = RAIIMLIRContextModule(allow_unregistered_dialects=True)
+gpu.set_container_module(ctx.module)
+
+@gpu.module("vec_kernels", ["#rocdl.target<abi = \"500\">"])
+def mod():
+    pass
+
+@flir.kernel
+def vecAdd(A: T.memref(N, T.f32()),
+           B: T.memref(N, T.f32()),
+           C: T.memref(N, T.f32())):
+    # Linear thread index
+    tid_linear = (flir.thread_idx("y") * flir.block_dim("x")
+                  + flir.thread_idx("x")).value
+
+    # Thread and value layouts
+    thr_layout = flir.make_ordered_layout((THREADS,), order=(0,))
+    val_layout = flir.make_ordered_layout((TILE,), order=(0,))
+
+    # Copy atom: f32, 4-wide vector loads
+    copy_atom = flir.make_copy_atom(T.f32(), vector_size=VEC)
+
+    # Tiled copy across all threads
+    tiled = flir.make_tiled_copy_tv(
+        copy_atom, thr_layout, val_layout,
+        thr_shape=(THREADS,), val_shape=(TILE,),
+    )
+
+    # Create tensors and partition into tiles
+    tensor_A = flir.make_tensor(A, shape=(N,), strides=(1,))
+    tiles_A = flir.zipped_divide(tensor_A, (THREADS * TILE,))
+    blkA = tiles_A[(flir.block_idx("x"),)]
+
+    # Get this thread's portion
+    thrA = tiled.get_slice(tid_linear).partition_S(blkA)
+    frgA = flir.make_fragment_like(thrA, T.f32())
+    flir.copy(tiled, thrA, frgA)
+
+    # ... repeat for B, add, store to C ...
+
+# Compile
+executor = compile(ctx.module)
+```
+
+---
+
+## 10. Kernel Launching
+
+After compilation, launch kernels through the executor:
+
+```python
+import torch
+
+# Create device tensors
+A = torch.randn(N, device="cuda", dtype=torch.float32)
+B = torch.randn(N, device="cuda", dtype=torch.float32)
+C = torch.empty(N, device="cuda", dtype=torch.float32)
+
+# Launch
+grid = (N // (THREADS * TILE), 1, 1)
+block = (THREADS, 1, 1)
+
+# For MlirModule-based kernels:
+executor = compile(mod)
+executor.vecAdd(A, B, C)
+
+# For GPUFunc-based kernels:
+vecAdd(A, B, C, grid_size=grid, block_size=block)
+```
+
+---
+
+## 11. Decision Tree
+
+```
+Writing a new kernel?
+
+├── Simple element-wise?
+│   ├── Use @flir.kernel with TensorView + copy
+│   └── See tests/kernels/test_vec_add.py
+│
+├── Reduction (norm, softmax)?
+│   ├── Use warp_reduce / block_reduce from kernels/reduce.py
+│   └── See kernels/layernorm_kernel.py, kernels/softmax_kernel.py
+│
+├── Matrix multiply (GEMM)?
+│   ├── Use MlirModule + SmemAllocator + MFMA
+│   ├── B-preshuffle layout from mfma_preshuffle_pipeline.py
+│   └── See kernels/preshuffle_gemm.py
+│
+├── Need shared memory?
+│   ├── Use SmemAllocator in MlirModule.__init__
+│   ├── Call finalize() in init_gpu_module()
+│   └── Call get_base() inside @kernel
+│
+└── Need custom pipeline?
+    ├── Use Pipeline fluent API
+    └── Or use flir.compile() with defaults
+```
+
+---
+
+## 12. Source Files
+
+| File | Description |
+|---|---|
+| `flydsl/src/flydsl/lang/ir/module.py` | `MlirModule`, `@kernel`, `@jit` decorators |
+| `flydsl/src/flydsl/dialects/ext/flir.py` | Layout API, TensorView, CopyAtom, TiledCopy, `copy()` |
+| `flydsl/src/flydsl/dialects/ext/gpu.py` | GPU dialect: `barrier()`, `LaunchFuncOp`, `GPUFuncOp` |
+| `flydsl/src/flydsl/dialects/ext/rocm.py` | ROCm helpers: MfmaOp, Copy ops |
+| `flydsl/src/flydsl/utils/smem_allocator.py` | `SmemAllocator`, `SmemPtr`, LDS capacity checks |
+| `flydsl/src/flydsl/compiler/compiler.py` | `compile()` entry point |
+| `flydsl/src/flydsl/compiler/context.py` | `RAIIMLIRContextModule` |
+| `flir/include/flir/FlirRocmOps.td` | ROCm dialect ops (MFMA, LDS, copy, barriers) |
+| `kernels/reduce.py` | Warp/block reduction primitives |
+| `tests/kernels/test_vec_add.py` | VecAdd example kernel |
+
+## 13. Test Files
+
+| File | Description |
+|---|---|
+| `tests/kernels/test_vec_add.py` | Vector add kernel test |
+| `tests/kernels/test_softmax.py` | Softmax kernel test |
+| `tests/kernels/test_layernorm.py` | LayerNorm kernel test |
+| `tests/kernels/test_preshuffle_gemm.py` | Preshuffle GEMM test |
+| `tests/kernels/test_eltwise_add.py` | Element-wise add test |
+| `tests/kernels/test_gpu_simple.py` | Simple GPU kernel tests |
+| `tests/kernels/test_shared_working.py` | Shared memory tests |

--- a/docs/layout_system_guide.md
+++ b/docs/layout_system_guide.md
@@ -1,0 +1,433 @@
+# FLIR Layout Algebra Guide
+
+> Core types, construction, coordinate mapping, algebra operations, and swizzling in the FLIR layout system.
+
+## Quick Reference
+
+| Operation | Python API | MLIR Op | Description |
+|---|---|---|---|
+| **Construction** | `flir.make_shape(8, 16)` | `flir.make_shape` | Create shape |
+| | `flir.make_stride(1, 8)` | `flir.make_stride` | Create stride |
+| | `flir.make_layout(shape, stride)` | `flir.make_layout` | Create layout from (shape, stride) |
+| | `flir.make_coord(i, j)` | `flir.make_coord` | Create coordinate |
+| | `flir.make_ordered_layout((8, 16), order=(1, 0))` | -- | Create layout with dimension ordering |
+| **Mapping** | `flir.crd2idx(coord, layout)` | `flir.crd2idx` | Coordinate → linear index |
+| | `flir.idx2crd(idx, layout)` | `flir.idx2crd` | Linear index → coordinate |
+| **Query** | `flir.size(layout)` | `flir.size` | Total element count |
+| | `flir.cosize(layout)` | `flir.cosize` | Codomain span |
+| | `flir.rank(layout)` | `flir.rank` | Number of dimensions |
+| | `flir.get(shape, idx)` | `flir.get` | Extract element at index |
+| **Algebra** | `flir.composition(A, B)` | `flir.composition` | Compose: A ∘ B |
+| | `flir.complement(tiler, size)` | `flir.complement` | Complement of tiler |
+| | `flir.coalesce(layout)` | `flir.coalesce` | Simplify layout |
+| **Products** | `flir.logical_product(A, B)` | `flir.logical_product` | Basic product |
+| | `flir.zipped_product(A, B)` | `flir.zipped_product` | Zipped product |
+| | `flir.tiled_product(A, B)` | `flir.tiled_product` | Tiled product |
+| | `flir.flat_product(A, B)` | `flir.flat_product` | Flat product |
+| | `flir.raked_product(A, B)` | `flir.raked_product` | Raked product |
+| | `flir.blocked_product(A, B)` | `flir.blocked_product` | Blocked product |
+| **Divides** | `flir.logical_divide(A, B)` | `flir.logical_divide` | Basic divide |
+| | `flir.zipped_divide(A, B)` | `flir.zipped_divide` | Zipped divide |
+| | `flir.tiled_divide(A, B)` | `flir.tiled_divide` | Tiled divide |
+| | `flir.flat_divide(A, B)` | `flir.flat_divide` | Flat divide |
+| **Partition** | `flir.local_partition(layout, tile, idx)` | `flir.local_partition` | Thread-local partition |
+| | `flir.local_tile(layout, tiler, coord)` | `flir.local_tile` | Extract tile at coordinate |
+
+---
+
+## 1. Core Types
+
+FLIR defines five custom MLIR types:
+
+| Type | MLIR Syntax | Description |
+|---|---|---|
+| `!flir.int` | `!flir.int` | Legacy integer type (compatibility) |
+| `!flir.shape<pattern>` | `!flir.shape<(8, 16)>` | Dimension extents -- can be nested |
+| `!flir.stride<pattern>` | `!flir.stride<(1, 8)>` | Memory strides -- can be nested |
+| `!flir.layout<shape:stride>` | `!flir.layout<(8, 16):(1, 8)>` | Layout = (Shape, Stride) pair |
+| `!flir.coord<pattern>` | `!flir.coord<(*, *)>` | Coordinate (flat, no nesting) |
+
+### Pattern Attributes
+
+Patterns encode the structure of shapes/strides/coords at the type level:
+
+| Pattern | Meaning | Example |
+|---|---|---|
+| Integer literal | Static constant | `8` |
+| `*` (`#flir.underscore`) | Wildcard (any value) | Used in rank-only types |
+| `?` (`#flir.dync_i32`) | Dynamic value (runtime) | SSA operand provides the value |
+| Nested tuple | Hierarchical mode | `(8, (4, 2))` |
+
+**Type-mode ops**: `make_shape`, `make_stride`, `make_coord` encode structure in the result type. Only dynamic leaves appear as SSA operands.
+
+---
+
+## 2. Construction
+
+### Python API
+
+```python
+from flydsl.dialects.ext import flir, arith
+
+# Constants
+c8 = arith.constant(8, index=True)
+c16 = arith.constant(16, index=True)
+c1 = arith.constant(1, index=True)
+
+# Basic construction
+shape = flir.make_shape(c8, c16)            # (8, 16)
+stride = flir.make_stride(c1, c8)           # (1, 8) -- column-major
+layout = flir.make_layout(shape, stride)    # ((8, 16), (1, 8))
+coord = flir.make_coord(i, j)              # (i, j)
+
+# Static constants (Python ints auto-materialized)
+shape = flir.make_shape(8, 16)              # Same as above
+layout = flir.make_layout((8, 16), (1, 8))  # Tuple shorthand
+
+# Nested shapes
+shape_nested = flir.make_shape(9, (4, 8))   # (9, (4, 8))
+
+# Ordered layout (convenience)
+layout_cm = flir.make_ordered_layout((8, 16), order=(1, 0))  # col-major
+layout_rm = flir.make_ordered_layout((8, 16), order=(0, 1))  # row-major
+```
+
+### MLIR
+
+```mlir
+// Create 2D layout (8, 16) with column-major stride (1, 8)
+%shape = flir.make_shape %c8, %c16 : (!flir.int, !flir.int) -> !flir.shape<2>
+%stride = flir.make_stride %c1, %c8 : (!flir.int, !flir.int) -> !flir.stride<2>
+%layout = flir.make_layout %shape, %stride
+    : (!flir.shape<2>, !flir.stride<2>) -> !flir.layout<2>
+%coord = flir.make_coord %i, %j : (index, index) -> !flir.coord<2>
+```
+
+---
+
+## 3. Coordinate Mapping
+
+The fundamental operation: mapping between logical coordinates and physical memory indices.
+
+**Formula**: `Index = dot(Coord, Stride) = sum(coord_i * stride_i)`
+
+### `crd2idx` -- Coordinate to Index
+
+```python
+# Python
+idx = flir.crd2idx(coord, layout)
+```
+
+```mlir
+// MLIR
+%idx = flir.crd2idx %coord, %layout : (!flir.coord<2>, !flir.layout<2>) -> index
+```
+
+### `idx2crd` -- Index to Coordinate (inverse)
+
+```python
+# Python
+coord = flir.idx2crd(idx, layout)
+```
+
+```mlir
+// MLIR
+%coord = flir.idx2crd %idx, %layout : (index, !flir.layout<2>) -> !flir.coord<2>
+```
+
+### Example
+
+For layout `((8, 16), (1, 8))` (8x16, column-major):
+- `crd2idx((3, 5), layout)` = `3*1 + 5*8` = `43`
+- `idx2crd(43, layout)` = `(43 % 8, 43 / 8)` = `(3, 5)`
+
+---
+
+## 4. Query Operations
+
+| Operation | Description | Example |
+|---|---|---|
+| `size(x)` | Product of all dimensions | `size((8, 16)) = 128` |
+| `cosize(layout)` | Span of the layout mapping (max index + 1) | `cosize(((8, 16), (1, 8))) = 128` |
+| `rank(x)` | Number of top-level dimensions | `rank((8, 16)) = 2` |
+| `get(x, i)` | Extract i-th element | `get((8, 16), 0) = 8` |
+| `get_shape(layout)` | Extract shape from layout | Returns `!flir.shape` |
+| `get_stride(layout)` | Extract stride from layout | Returns `!flir.stride` |
+
+```python
+s = flir.size(layout)       # total elements
+cs = flir.cosize(layout)    # codomain span
+r = flir.rank(layout)       # number of modes
+v = flir.get(shape, 0)      # first dimension
+
+shape = flir.get_shape(layout)
+stride = flir.get_stride(layout)
+```
+
+---
+
+## 5. Layout Algebra
+
+### 5.1 Composition: `composition(A, B)`
+
+Composes two layouts: result maps through B first, then A.
+
+**Semantics**: `result(x) = A(B(x))`
+
+```python
+composed = flir.composition(layout_a, layout_b)
+```
+
+```mlir
+%composed = flir.composition %layoutA, %layoutB
+    : (!flir.layout<2>, !flir.layout<2>) -> !flir.layout<2>
+```
+
+**Use case**: Applying a permutation to a layout, or composing a tile coordinate mapping with a memory layout.
+
+### 5.2 Complement: `complement(tiler, target_size)`
+
+Computes the "remaining" modes not covered by the tiler, up to `target_size` elements.
+
+```python
+rest = flir.complement(tiler, target_size)
+```
+
+**Algorithm**:
+1. Filter out stride-0 and size-1 modes from the tiler
+2. Sort modes by stride (ascending)
+3. Fold to compute rest modes
+
+**Use case**: Internal building block for `logical_divide`. Also useful for computing the complementary iteration space when tiling.
+
+### 5.3 Coalesce: `coalesce(layout)`
+
+Simplifies a layout by flattening nested modes and combining adjacent modes when possible.
+
+**Post-conditions**:
+- `size(result) == size(layout)` (preserves total size)
+- `result` has depth ≤ 1 (flattened)
+- For all valid indices: `layout(i) == result(i)` (preserves mapping)
+
+```python
+simplified = flir.coalesce(layout)
+```
+
+---
+
+## 6. Product Operations
+
+Products combine two layouts to create a larger layout. All products take `(block, tiler)` and produce a result layout.
+
+| Variant | Description |
+|---|---|
+| `logical_product` | Mode-wise concatenation (most basic). Scales tiler strides by block size. |
+| `zipped_product` | Interleaves modes from block and tiler. |
+| `tiled_product` | Creates hierarchical tiled structure. |
+| `flat_product` | Produces a flattened result. |
+| `raked_product` | Creates a raked (interleaved) access pattern. |
+| `blocked_product` | Creates a blocked access pattern. |
+
+```python
+result = flir.logical_product(block_layout, tiler_layout)
+result = flir.zipped_product(block_layout, tiler_layout)
+result = flir.raked_product(block_layout, tiler_layout)
+# ... etc
+```
+
+### Example
+
+```python
+# Thread layout: 4 threads along M, 32 along N
+thr_layout = flir.make_ordered_layout((4, 32), order=(1, 0))
+
+# Value layout: each thread handles 4x4 elements
+val_layout = flir.make_ordered_layout((4, 4), order=(1, 0))
+
+# Raked product: interleaved access across threads
+raked = flir.raked_product(thr_layout, val_layout)
+```
+
+---
+
+## 7. Divide Operations
+
+Divides partition a layout by a tiler, creating a view that separates "tile" and "rest" dimensions.
+
+| Variant | Description |
+|---|---|
+| `logical_divide` | Basic partitioning. Internally uses `complement`. |
+| `zipped_divide` | Zipped division semantics. |
+| `tiled_divide` | Hierarchical tiled division. |
+| `flat_divide` | Flattened division. |
+
+```python
+result = flir.logical_divide(layout, tiler)
+result = flir.zipped_divide(layout, tiler)
+```
+
+### `zipped_divide` with TensorView
+
+`zipped_divide` has special support for `TensorView` objects, enabling block-level tiling:
+
+```python
+tensor = flir.make_tensor(A, shape=(M, N), strides=(N, 1))
+tiles = flir.zipped_divide(tensor, (TILE_M, TILE_N))
+
+# Index with block coordinates to get a tile
+blk_tile = tiles[(flir.block_idx("y"), flir.block_idx("x"))]
+```
+
+---
+
+## 8. Local Partition & Tile
+
+### `local_partition(layout, tile, index)`
+
+Partitions a layout for a specific thread/block index:
+
+```python
+# Partition layout by tile for thread `tid`
+thr_portion = flir.local_partition(layout, tile_layout, tid)
+```
+
+### `local_tile(layout, tiler, coord)`
+
+Extracts a tile from a layout at specific coordinates:
+
+```python
+tile = flir.local_tile(layout, tile_shape, block_coord)
+```
+
+---
+
+## 9. Helper Functions
+
+### `make_ordered_layout(shape, order, stride)`
+
+Creates a layout with specified dimension ordering:
+
+```python
+# Column-major (N is the fast-changing dimension)
+layout_cm = flir.make_ordered_layout((M, N), order=(1, 0))
+
+# Row-major (M is the fast-changing dimension)
+layout_rm = flir.make_ordered_layout((M, N), order=(0, 1))
+```
+
+When `order` is provided, strides are computed automatically. When `stride` is provided instead, it's used directly.
+
+### `product_each(shape)`
+
+Element-wise product of nested shape dimensions:
+
+```python
+# If shape is ((4, 8), (2, 16)):
+# product_each returns (32, 32) -- products within each mode
+result = flir.product_each(shape)
+```
+
+### `make_layout_tv(thr_layout, val_layout)`
+
+Creates a tiler and TV (thread-value) layout from separate thread and value layouts. Used internally by `make_tiled_copy_tv`.
+
+---
+
+## 10. Swizzling
+
+### `swizzle_xor16(row, col, kBlocks16)`
+
+XOR-based swizzle for LDS bank-conflict avoidance at 16-byte granularity:
+
+**Formula**: `result = col XOR ((row % kBlocks16) * 16)`
+
+```python
+col_swizzled = flir.swizzle_xor16(row, col, k_blocks16)
+```
+
+```mlir
+%swizzled = flir.swizzle_xor16 %row, %col, %kBlocks16
+    : (index, index, index) -> index
+```
+
+This matches the CK/ROCDSL-style LDS swizzle used for FP8/F16 tiles where the K dimension is permuted at 16-byte granularity while preserving intra-16B order.
+
+**Usage in kernels**: Applied when storing tiles to LDS to avoid bank conflicts:
+
+```python
+# In preshuffle GEMM kernels:
+col_bytes = col_i32 * arith.constant(4, index=True)
+col_swz = flir.swizzle_xor16(row, col_bytes, k_blocks16)
+coord = flir.make_coord(row, col_swz)
+idx = flir.crd2idx(coord, lds_layout)
+```
+
+---
+
+## 11. Nested / Hierarchical Layouts
+
+FLIR supports nested layouts for representing multi-level tiling hierarchies:
+
+```python
+# Nested shape: 9 elements in first mode, (4, 8) = 32 elements in second
+shape = flir.make_shape(9, (4, 8))
+
+# This represents a 2-level hierarchy:
+# - Outer: 9 x 4
+# - Inner: 4 within each outer element, 8 within each inner group
+```
+
+Nested layouts are used in GEMM kernels for multi-level tiling (block → warp → thread → instruction).
+
+---
+
+## 12. Decision Tree
+
+```
+Which layout operation do I need?
+
+├── Creating a layout?
+│   ├── From explicit shape + stride → make_layout(shape, stride)
+│   ├── With dimension ordering → make_ordered_layout(shape, order)
+│   └── From existing layout components → make_layout(get_shape(l), new_stride)
+│
+├── Querying a layout?
+│   ├── Total elements → size(layout)
+│   ├── Memory span → cosize(layout)
+│   ├── Number of modes → rank(layout)
+│   └── Extract component → get(shape, i), get_shape(layout), get_stride(layout)
+│
+├── Coordinate mapping?
+│   ├── Coord → memory index → crd2idx(coord, layout)
+│   └── Memory index → coord → idx2crd(idx, layout)
+│
+├── Combining layouts?
+│   ├── Sequential mapping (A then B) → composition(A, B)
+│   ├── Extending to more threads → logical_product / raked_product / blocked_product
+│   └── Simplifying → coalesce(layout)
+│
+├── Partitioning / tiling?
+│   ├── Split layout into tiles → logical_divide / zipped_divide
+│   ├── Get one thread's portion → local_partition(layout, tile, thread_id)
+│   └── Get one block's tile → local_tile(layout, tile_shape, block_coord)
+│
+└── LDS bank-conflict avoidance?
+    └── XOR swizzle → swizzle_xor16(row, col, k_blocks16)
+```
+
+---
+
+## 13. Source Files
+
+| File | Description |
+|---|---|
+| `flir/include/flir/FlirOps.td` | All FLIR op definitions (construction, query, algebra, divide, product, local ops) |
+| `flir/include/flir/FlirTypeDefs.td` | Type definitions (`!flir.shape`, `!flir.stride`, `!flir.layout`, `!flir.coord`) |
+| `flir/include/flir/FlirAttrDefs.td` | Attribute definitions (`#flir.underscore`, `#flir.dync_i32`) |
+| `flir/lib/Dialect/Flir/FlirLayoutAlgebra.cpp` | Type inference for composition, logical_product, logical_divide |
+| `flir/lib/Dialect/Flir/FlirOps.cpp` | Op verifiers and custom builders |
+| `flydsl/src/flydsl/dialects/ext/flir.py` | Python API: all layout functions, TensorView, CopyAtom, TiledCopy |
+| `tests/pyir/test_layout_algebra.py` | Layout algebra tests (composition, complement, coalesce) |
+| `tests/pyir/test_product_divide.py` | Product and divide operation tests |
+| `tests/pyir/test_nested_layouts.py` | Nested/hierarchical layout tests |
+| `tests/pyir/test_local_ops.py` | local_partition and local_tile tests |

--- a/docs/prebuilt_kernels_guide.md
+++ b/docs/prebuilt_kernels_guide.md
@@ -1,0 +1,379 @@
+# Pre-built Kernel Library Guide
+
+> Available FlyDSL kernels: Normalization, Softmax, GEMM, Mixed-precision GEMM, MoE GEMM -- configuration, data types, pipelines, and shared utilities.
+
+## Quick Reference
+
+| Kernel | Builder Function | Dtypes | Key Feature |
+|---|---|---|---|
+| **LayerNorm** | `build_layernorm_module(M, N, dtype)` | f32, f16, bf16 | Two-pass vectorized normalization |
+| **RMSNorm** | `build_rmsnorm_module(M, N, dtype)` | f32, f16, bf16 | LDS-cached 3-pass pipeline |
+| **Softmax** | `build_softmax_module(M, N, dtype)` | f32, f16, bf16 | Online softmax, adaptive block size |
+| **GEMM** | `compile_preshuffle_gemm_a8(...)` | fp8, int8, int4, fp16, bf16 | Preshuffle B, ping-pong LDS, MFMA 16x16 |
+| **Mixed GEMM** | `compile_mxfp4_preshuffle_gemm(...)` | A:fp8/fp4, B:fp4 | MXFP4 mixed-precision with per-block scales |
+| **MoE GEMM** | `compile_moe_gemm1(...)` | fp8, fp16, int8, int4 | Dual accumulator, SiLU gating, expert routing |
+| **Mixed MoE GEMM** | `compile_mixed_moe_gemm1(...)` | A:fp8/fp4, B:fp4 | MXFP4 MoE with separate A/B scales |
+
+---
+
+## 1. Normalization Kernels
+
+### 1.1 LayerNorm (`kernels/layernorm_kernel.py`)
+
+Computes `LayerNorm(x) = (x - mean) / sqrt(var + eps) * gamma + beta` for each row.
+
+**Builder:**
+```python
+from kernels.layernorm_kernel import build_layernorm_module
+
+executor = build_layernorm_module(M=32768, N=8192, dtype_str="bf16")
+```
+
+**Configuration Constants:**
+| Constant | Value | Description |
+|---|---|---|
+| `BLOCK_THREADS` | 256 | Threads per block |
+| `WARP_SIZE` | 64 | AMD wavefront size |
+| `VEC_WIDTH` | 8 | Vector load/store width |
+| `VEC_ALIGN` | 16 | Alignment for vector ops (bytes) |
+| `EPS` | 1e-5 | Numerical stability epsilon |
+| `USE_NONTEMPORAL` | True | Non-temporal stores for output |
+
+**Algorithm:**
+- **Two-pass normalization**: Pass 1 computes mean and variance, Pass 2 applies affine transform
+- **Fast path**: When `N == BLOCK_THREADS * VEC_WIDTH * 4` (e.g., N=8192), uses fully register-resident computation with no scalar tail
+- **Generic path**: Handles arbitrary N with vector body + scalar tail
+- **bf16 handling**: Software round-to-nearest-even (RNE) pack on gfx942; hardware `cvt_pk_bf16_f32` on gfx950+
+- **Warp reduction**: XOR-shuffle-based intra-wave reduction (shifts: 32, 16, 8, 4, 2, 1), then LDS-based cross-wave synchronization
+
+**Kernel signature** (inside the `_LayerNorm` MlirModule):
+```
+GPU_MODULE_NAME = "layernorm_module"
+
+@kernel
+layernorm_kernel(self, Input, Gamma, Beta, Output, m_in)
+
+@jit
+__call__(self, Input, Gamma, Beta, Output, m_in)
+```
+
+### 1.2 RMSNorm (`kernels/rmsnorm_kernel.py`)
+
+Computes `RMSNorm(x) = x / sqrt(mean(x^2) + eps) * gamma`.
+
+**Builder:**
+```python
+from kernels.rmsnorm_kernel import build_rmsnorm_module
+
+executor = build_rmsnorm_module(M=32768, N=8192, dtype_str="bf16")
+```
+
+**Configuration Constants:** Same as LayerNorm (BLOCK_THREADS=256, VEC_WIDTH=8, etc.)
+
+**Algorithm (3-pass with LDS caching):**
+1. **Pass 0**: Global → LDS row cache (one-pass global read, vectorized)
+2. **Pass 1**: Sum-of-squares computation from LDS row cache
+3. **Pass 2**: Normalize + gamma multiply + store with software pipeline for Gamma prefetch
+
+**Kernel signature:**
+```
+GPU_MODULE_NAME = "rmsnorm_module"
+
+@kernel
+rmsnorm_kernel(self, Input, Gamma, Output, m_in)
+```
+
+---
+
+## 2. Softmax Kernel
+
+### 2.1 Softmax (`kernels/softmax_kernel.py`)
+
+Computes row-wise softmax: `softmax(x)_i = exp(x_i - max(x)) / sum(exp(x - max(x)))`.
+
+**Builder:**
+```python
+from kernels.softmax_kernel import build_softmax_module
+
+executor = build_softmax_module(M=32768, N=8192, dtype_str="bf16")
+```
+
+**Configuration:**
+| Parameter | Value | Description |
+|---|---|---|
+| `BLOCK_SIZE` | `min(256, next_power_of_2(N))`, min 32 | Adaptive block size |
+| `VEC_WIDTH` | 8 | Vector load/store width |
+| `WARP_SIZE` | 64 | AMD wavefront size |
+
+**Algorithm (6 stages):**
+1. **Load Data**: Vectorized global loads into register buffer with validity masks
+2. **Local Max**: Per-thread vector reduction (`maxnumf`)
+3. **Global Max**: Block-wide shuffle reduction (intra-wave XOR → wave0 finalize via LDS)
+4. **Local Exp + Sum**: `exp2(x * log2(e))` approximation, accumulate partial sums
+5. **Global Sum**: Block-wide reduction for sum
+6. **Normalize + Store**: Divide by sum, convert to output dtype, vectorized store
+
+**Kernel signature:**
+```
+GPU_MODULE_NAME = f"softmax_{dtype_str}"  # e.g., "softmax_bf16"
+
+@kernel
+softmax_kernel(self, A, C, m_in)
+```
+
+---
+
+## 3. GEMM Kernels
+
+### 3.1 Preshuffle GEMM (`kernels/preshuffle_gemm.py`)
+
+MFMA 16x16-based GEMM with B-matrix preshuffle layout: `C[M,N] = A[M,K] @ B[N,K]^T`.
+
+**Builder:**
+```python
+from kernels.preshuffle_gemm import compile_preshuffle_gemm_a8
+
+executor = compile_preshuffle_gemm_a8(
+    M=16, N=5120, K=8192,
+    tile_m=16, tile_n=128, tile_k=256,
+    in_dtype="fp8",
+    lds_stage=2,
+    use_cshuffle_epilog=False,
+)
+```
+
+**Parameters:**
+| Parameter | Type | Description |
+|---|---|---|
+| `M, N, K` | int | GEMM dimensions: A[M,K], B[N,K], C[M,N] |
+| `tile_m, tile_n, tile_k` | int | Block tile sizes |
+| `in_dtype` | str | `"fp8"`, `"int8"`, `"int4"`, `"fp16"`, `"bf16"` |
+| `lds_stage` | int | `2` = ping-pong LDS (tuned), `1` = single LDS buffer |
+| `use_cshuffle_epilog` | bool | CK-style LDS CShuffle epilogue |
+
+**Key constraints:**
+- `tile_m * tile_k * elem_bytes` must be divisible by `total_threads` (256)
+- `tile_k * elem_bytes` must be divisible by 64 (K64-byte micro-step)
+- INT4 is W4A8: A is int8, B is packed int4 (2 values/byte), unpacked to int8 in-kernel
+
+**Pipeline details:**
+- **lds_stage=2 (ping-pong)**: Two LDS buffers for A tiles. Cross-tile A0 prefetch overlaps VMEM with LDS reads
+- **lds_stage=1 (single)**: CK-style intrawave schedule with single LDS buffer
+- **K64-byte micro-step**: Each step issues 2x K32 MFMA operations (fp8/int8: 64 elements, fp16/bf16: 32 elements)
+- **XOR16 swizzle**: Byte-level swizzle on LDS to avoid bank conflicts
+- **B-preshuffle**: Shape (N0, K0, KLane, NLane, KPackBytes) = (N/16, K/64, 4, 16, kpack_bytes)
+- **CShuffle epilogue**: Write C tile to LDS in row-major, remap threads for half2 packing via `ds_bpermute`
+
+### 3.2 Mixed-Precision GEMM (`kernels/mixed_preshuffle_gemm.py`)
+
+MXFP4 mixed-precision GEMM with separate A/B quantization scales.
+
+**Builder:**
+```python
+from kernels.mixed_preshuffle_gemm import compile_mxfp4_preshuffle_gemm
+
+executor = compile_mxfp4_preshuffle_gemm(
+    M=16, N=5120, K=8192,
+    tile_m=16, tile_n=128, tile_k=256,
+    a_dtype="fp8", b_dtype="fp4",
+    lds_stage=2,
+    use_cshuffle_epilog=True,
+)
+```
+
+**Parameters:**
+| Parameter | Type | Description |
+|---|---|---|
+| `a_dtype` | str | `"fp8"` or `"fp4"` for A matrix |
+| `b_dtype` | str | `"fp4"` for B matrix |
+| `use_cshuffle_epilog` | bool | Default `True` for mixed GEMM |
+
+**Key features:**
+- K128 stepping with per-pack scale factors
+- Packed FP4 element handling (2 elements per byte)
+- Separate scale loading for A and B paths with `quant_block_size=32`
+- Uses `mfma_scale_x128` on gfx950+ (9-operand scaling MFMA)
+
+---
+
+## 4. MoE GEMM Kernels
+
+### 4.1 MoE GEMM 2-Stage (`kernels/moe_gemm_2stage.py`)
+
+Mixture-of-Experts GEMM with dual accumulators for gate/up projections and SiLU gating.
+
+**Stage 1 Builder:**
+```python
+from kernels.moe_gemm_2stage import compile_moe_gemm1
+
+executor = compile_moe_gemm1(
+    model_dim=8192, inter_dim=8192,
+    experts=16, topk=4,
+    tile_m=64, tile_n=128, tile_k=128,
+    doweight_stage1=True,
+    in_dtype="fp8", out_dtype="f16",
+)
+```
+
+**Parameters:**
+| Parameter | Type | Description |
+|---|---|---|
+| `model_dim` | int | Model hidden dimension |
+| `inter_dim` | int | Intermediate dimension |
+| `experts` | int | Number of experts |
+| `topk` | int | Top-K experts per token |
+| `tile_m, tile_n, tile_k` | int | Block tile sizes |
+| `doweight_stage1` | bool | Apply sorted weights in stage1 epilogue |
+| `in_dtype` | str | `"fp8"`, `"fp16"`, `"int8"`, `"int4"` |
+| `out_dtype` | str | `"f16"` or `"bf16"` |
+
+**Key features:**
+- **Dual accumulator**: `acc_gate` and `acc_up` for gate and up projections
+- **SiLU activation**: `silu(x) = x * sigmoid(x)` using `exp2` + `rcp` for efficiency
+- **Dynamic expert routing**: Expert ID lookup per M-tile
+- **Sorted token masking**: Sentinel value for out-of-bounds token safety
+- **Block validity gating**: Skip invalid M tiles early
+- **CShuffle epilogue**: Optional, with sorted weight and scale blending
+
+**Kernel signature:**
+```
+GPU_MODULE_NAME = f"mfma_moe1_{in_dtype}_{out_dtype}_{epilog_tag}_t{tile_m}x{tile_n}x{tile_k}_abi3"
+
+@kernel
+moe_gemm1(self, arg_out, arg_x, arg_w, arg_scale_x, arg_scale_w,
+          arg_sorted_token_ids, arg_expert_ids, arg_sorted_weights,
+          arg_max_token_ids, tokens_in, inter_in, k_in, size_expert_ids_in)
+```
+
+### 4.2 Mixed MoE GEMM (`kernels/mixed_moe_gemm_2stage.py`)
+
+MXFP4 variant of MoE GEMM combining dual-accumulator pattern with mixed-precision scales.
+
+**Builder:**
+```python
+from kernels.mixed_moe_gemm_2stage import compile_mixed_moe_gemm1
+
+executor = compile_mixed_moe_gemm1(
+    model_dim=8192, inter_dim=8192,
+    experts=16, topk=4,
+    tile_m=64, tile_n=128, tile_k=256,
+    doweight_stage1=True,
+    a_dtype="fp8", b_dtype="fp4",
+    out_dtype="f16",
+)
+```
+
+---
+
+## 5. Shared Utilities
+
+### 5.1 Reduction Helpers (`kernels/reduce.py`)
+
+Reusable warp and block reduction functions.
+
+| Function | Description |
+|---|---|
+| `reduce_vec_max(vec, VEC_WIDTH, ...)` | Vector reduction to max via `maxnumf` |
+| `reduce_vec_sum(vec, VEC_WIDTH, ...)` | Vector reduction to sum via `add` |
+| `make_block_reduce(tid, BLOCK_SIZE, ...)` | Block-wide reduction: intra-wave XOR shuffle → LDS cross-wave sync |
+| `make_block_reduce_add(tid, ...)` | Block reduction for addition (single-wave fast path) |
+| `make_block_reduce_add2(tid, ...)` | Dual independent scalar reduction |
+
+**Reduction pattern:**
+1. Intra-wave: XOR shuffle with shifts 32, 16, 8, 4, 2, 1 (wave64)
+2. Lane 0 writes per-wave partial to LDS
+3. Barrier
+4. Wave 0 reduces `NUM_WAVES` partials from LDS
+
+### 5.2 MFMA Epilogues (`kernels/mfma_epilogues.py`)
+
+Configurable epilogue strategies for MFMA 16x16 kernels.
+
+| Function | Description |
+|---|---|
+| `default_epilog(...)` | Standard row-iterator: `row = bx_m + mi*16 + lane_div_16*4 + ii` |
+| `c_shuffle_epilog(...)` | CK-style LDS CShuffle: write to LDS → barrier → remap threads (8,32) → half2 store |
+| `mfma_epilog(use_cshuffle, ...)` | Dispatcher: calls default or CShuffle based on flag |
+
+### 5.3 Preshuffle Pipeline (`kernels/mfma_preshuffle_pipeline.py`)
+
+Shared data movement and layout utilities for preshuffle GEMM/MoE kernels.
+
+| Function | Description |
+|---|---|
+| `make_preshuffle_b_layout(flir, arith, N, K, ...)` | Build B-preshuffle layout: (N/16, K/64, 4, 16, kpack_bytes) |
+| `make_preshuffle_scale_layout(...)` | Build scale layout for MXFP4 quantization |
+| `load_b_pack_k32(...)` | Load B pack for K32 MFMA micro-step (returns i64) |
+| `tile_chunk_coord_i32(...)` | Map (thread, chunk) → (row, col) for tile loads |
+| `buffer_copy_gmem16_dwordx4(...)` | 16-byte global load via buffer-load dwordx4 |
+| `lds_store_16b_xor16(...)` | Store 16B to LDS with XOR16 swizzle |
+| `lds_store_8b_xor16(...)` | Store 8B to LDS with XOR16 swizzle |
+| `lds_store_4b_xor16(...)` | Store 4B to LDS with XOR16 swizzle |
+| `lds_load_pack_k32(...)` | Load A-pack from LDS for K32 micro-step |
+
+---
+
+## 6. Kernel Decision Tree
+
+```
+What operation do you need?
+│
+├── Normalization
+│   ├── Need bias (beta) term? → LayerNorm (layernorm_kernel.py)
+│   └── No bias term?         → RMSNorm (rmsnorm_kernel.py)
+│
+├── Softmax
+│   └── Row-wise softmax      → Softmax (softmax_kernel.py)
+│
+├── Matrix Multiply (GEMM)
+│   ├── Standard GEMM (uniform precision)
+│   │   ├── FP8 / INT8 / INT4(W4A8) / FP16 / BF16
+│   │   └── → compile_preshuffle_gemm_a8()
+│   │
+│   ├── Mixed-precision GEMM (FP4 weights)
+│   │   ├── A: fp8 or fp4,  B: fp4
+│   │   └── → compile_mxfp4_preshuffle_gemm()
+│   │
+│   ├── MoE GEMM (expert routing)
+│   │   ├── Uniform precision (fp8/fp16/int8/int4)
+│   │   └── → compile_moe_gemm1()
+│   │
+│   └── Mixed MoE GEMM (FP4 expert weights)
+│       ├── A: fp8 or fp4,  B: fp4
+│       └── → compile_mixed_moe_gemm1()
+│
+└── Building blocks
+    ├── Warp/block reduction     → reduce.py
+    ├── MFMA epilogue selection  → mfma_epilogues.py
+    └── Preshuffle data movement → mfma_preshuffle_pipeline.py
+```
+
+---
+
+## 7. Source Files
+
+| File | Description |
+|---|---|
+| `kernels/__init__.py` | Package marker |
+| `kernels/kernels_common.py` | `stream_ptr_to_async_token()` helper |
+| `kernels/layernorm_kernel.py` | LayerNorm builder (`_LayerNorm` MlirModule) |
+| `kernels/rmsnorm_kernel.py` | RMSNorm builder (`_RMSNorm` MlirModule) |
+| `kernels/softmax_kernel.py` | Softmax builder (`_Softmax` MlirModule) |
+| `kernels/preshuffle_gemm.py` | Preshuffle GEMM builder (`_GEMM` MlirModule) |
+| `kernels/mixed_preshuffle_gemm.py` | Mixed-precision GEMM builder (`_GEMM` MlirModule) |
+| `kernels/moe_gemm_2stage.py` | MoE GEMM 2-stage builder (`_MOE1` MlirModule) |
+| `kernels/mixed_moe_gemm_2stage.py` | Mixed MoE GEMM builder (`_MOE1` MlirModule) |
+| `kernels/reduce.py` | Shared warp/block reduction helpers |
+| `kernels/mfma_epilogues.py` | MFMA epilogue strategies (default, CShuffle) |
+| `kernels/mfma_preshuffle_pipeline.py` | Preshuffle data movement and layout utilities |
+
+## 8. Test Files
+
+| File | Tests |
+|---|---|
+| `tests/kernels/test_layernorm.py` | LayerNorm correctness + perf vs PyTorch/AIter |
+| `tests/kernels/test_rmsnorm.py` | RMSNorm correctness + perf |
+| `tests/kernels/test_softmax.py` | Softmax correctness + perf vs PyTorch/AIter |
+| `tests/kernels/test_preshuffle_gemm.py` | GEMM fp8/int8/int4/bf16 correctness + perf |
+| `tests/kernels/test_moe_gemm.py` | MoE GEMM stage1/stage2 correctness + perf |
+| `tests/kernels/benchmark_common.py` | Shared benchmark infrastructure (FLIR vs AIter) |

--- a/docs/testing_benchmarking_guide.md
+++ b/docs/testing_benchmarking_guide.md
@@ -1,0 +1,454 @@
+# Testing & Benchmarking Guide
+
+> Test infrastructure, running tests, benchmark harness, writing new tests, and performance comparison with AIter.
+
+## Quick Reference
+
+| Category | Location | Requires GPU | Description |
+|---|---|---|---|
+| **MLIR IR tests** | `tests/mlir/*.mlir` | No | Verify FLIR → standard lowering |
+| **Python IR tests** | `tests/pyir/test_*.py` | No | Python-based MLIR generation + lowering |
+| **GPU kernel tests** | `tests/kernels/test_*.py` | Yes | Full compilation → GPU execution |
+| **Benchmarks** | `scripts/run_benchmark.sh` | Yes | Performance characterization |
+
+**Run all tests:**
+```bash
+bash scripts/run_tests.sh
+```
+
+**Run benchmarks:**
+```bash
+bash scripts/run_benchmark.sh
+```
+
+---
+
+## 1. Test Categories
+
+### 1.1 MLIR IR Tests (`tests/mlir/`)
+
+Direct MLIR lowering verification using the `flir-opt` tool. These tests validate that FLIR operations lower correctly to standard MLIR dialects without needing a GPU.
+
+**Files:**
+| Test File | Description |
+|---|---|
+| `test_basic.mlir` | Basic FLIR operation lowering |
+| `test_simple.mlir` | Simple layout operations |
+| `test_ops.mlir` | General FLIR ops |
+| `test_all_ops.mlir` | Comprehensive op coverage |
+| `test_crd2idx.mlir` | Coordinate-to-index mapping |
+| `test_idx2crd.mlir` | Index-to-coordinate mapping |
+| `test_size.mlir` | Size query operation |
+| `test_cosize.mlir` | Cosize query operation |
+| `test_rank.mlir` | Rank query operation |
+| `test_get.mlir` | Get (element access) operation |
+| `test_composition.mlir` | Layout composition |
+| `test_product_divide.mlir` | Product and divide operations |
+| `test_all_product_divide.mlir` | All product/divide variants |
+| `test_local_ops.mlir` | local_partition and local_tile |
+| `test_layout.mlir` | Layout construction |
+| `test_layout_amd.mlir` | AMD-specific layout patterns |
+| `test_chained.mlir` | Chained operations |
+| `test_chained_operations.mlir` | Complex chained sequences |
+| `test_coord_lowering.mlir` | Static coordinate lowering |
+| `test_coord_lowering_dynamic.mlir` | Dynamic coordinate lowering |
+| `test_pass.mlir` | Pass pipeline |
+| `comprehensive_test.mlir` | Full integration test |
+
+**Running individually:**
+```bash
+# Build flir-opt first if needed
+cmake --build .flir/build --target flir-opt -j$(nproc)
+
+# Run a single test
+.flir/build/bin/flir-opt --flir-to-standard tests/mlir/test_basic.mlir
+```
+
+### 1.2 Python IR Tests (`tests/pyir/`)
+
+Python-based tests that generate MLIR IR using the FlyDSL Python API and verify the IR structure and lowering. No GPU execution required.
+
+**Files:**
+| Test File | Description |
+|---|---|
+| `test_layout_algebra.py` | Layout algebra: coalesce, composition, divide, product, complement |
+| `test_product_divide.py` | Pythonic product/divide operator tests |
+| `test_local_ops.py` | Thread-level partitioning and tiling |
+| `test_nested_layouts.py` | Nested/hierarchical layout construction |
+| `test_basic_ops.py` | Basic FLIR operation generation |
+| `test_arith_operators.py` | Arithmetic operator overloading |
+| `test_passes.py` | Pipeline pass execution |
+| `test_static_vs_dynamic.py` | Static vs dynamic value handling |
+| `test_lang_module_descriptors.py` | MlirModule @kernel/@jit descriptors |
+| `test_rocdl_ops.py` | ROCm dialect operations |
+| `test_rocir_basic.py` | ROCm IR basic ops |
+| `test_rocir_coord_ops.py` | ROCm coordinate operations |
+| `test_rocir_product.py` | ROCm product operations |
+| `test_rocir_divide.py` | ROCm divide operations |
+| `test_rocir_local.py` | ROCm local operations |
+| `test_rocir_print.py` | ROCm IR printing |
+
+**Running individually:**
+```bash
+python tests/pyir/test_layout_algebra.py
+```
+
+### 1.3 GPU Kernel Tests (`tests/kernels/`)
+
+Full end-to-end tests: compile FlyDSL kernels to HSACO binary, execute on GPU, validate against PyTorch reference.
+
+**Files:**
+| Test File | Kernel | Description |
+|---|---|---|
+| `test_vec_add.py` | VecAdd | Vector addition (C = A + B) |
+| `test_softmax.py` | Softmax | Row-wise softmax |
+| `test_layernorm.py` | LayerNorm | Layer normalization |
+| `test_rmsnorm.py` | RMSNorm | RMS normalization |
+| `test_preshuffle_gemm.py` | GEMM | Preshuffle MFMA GEMM (fp8/int8/int4/bf16) |
+| `test_moe_gemm.py` | MoE GEMM | MoE 2-stage GEMM |
+| `test_eltwise_add.py` | EltAdd | Element-wise addition |
+| `test_matrix_trans.py` | Transpose | Matrix transpose |
+| `test_quant.py` | Quantization | Quantization ops |
+| `test_gpu_simple.py` | Simple GPU | Minimal GPU kernel test |
+| `test_gpu_layout.py` | Layout GPU | GPU layout operations |
+| `test_gpu_rocdsl.py` | ROCm DSL | ROCm DSL integration |
+| `test_gpu_with_rocir_coords.py` | Coords GPU | Coordinate operations on GPU |
+| `test_shared_working.py` | Shared Mem | Shared memory operations |
+| `test_ref.py` | Reference | Reference implementations |
+
+**Running individually:**
+```bash
+python tests/kernels/test_softmax.py
+python tests/kernels/test_preshuffle_gemm.py --in_dtype fp8 -M 16 -N 5120 -K 8192
+```
+
+---
+
+## 2. Test Runner Scripts
+
+### 2.1 `scripts/run_tests.sh`
+
+Main test orchestrator that runs all 4 test categories sequentially.
+
+**Environment setup:**
+```bash
+# Auto-detected PYTHONPATH
+PYTHONPATH="${REPO_ROOT}/flydsl/src:${BUILD_DIR}/python_packages/flydsl:${REPO_ROOT}:${PYTHONPATH}"
+```
+
+**Categories executed:**
+1. **MLIR IR tests**: Iterates `tests/mlir/*.mlir`, runs `flir-opt --flir-to-standard`
+2. **Python IR tests**: Runs `tests/pyir/test_*.py`
+3. **GPU execution tests**: Detects ROCm via `rocm-smi`, runs `tests/kernels/test_*.py`
+4. **GPU HIPGraph tests**: Runs GEMM/MoE tests with `-tg` flag for graph capture mode
+
+**Output:**
+- Logs to `/tmp/{test_name}.log`
+- Extracts performance metrics (TFLOPS, bandwidth) from output
+- Final summary with pass/fail counts
+
+### 2.2 `scripts/run_benchmark.sh`
+
+Specialized benchmarking harness for performance characterization.
+
+**Default configurations:**
+```bash
+# Softmax/LayerNorm
+SOFTMAX_SHAPES='32768,8192,bf16'
+LAYERNORM_SHAPES='32768,8192,bf16'
+
+# Preshuffle GEMM: "dtype,M,N,K,tile_m,tile_n,tile_k"
+GEMM_SHAPES='
+fp8,16,40960,5120,16,128,256
+fp8,16,77824,5120,16,128,256
+fp8,5120,5120,8320,64,256,128
+fp8,9728,8192,8320,64,256,128
+int8,9728,8192,8320,64,256,128
+'
+
+# MoE: "tokens,model_dim,inter_dim,experts,topk,tile_m,tile_n,tile_k,tile_n2,tile_k2"
+MOE_SHAPES='
+32768,8192,8192,16,4,64,128,128,256,128
+64,6144,1024,128,8,16,64,256,64,256
+'
+```
+
+**Selective execution:**
+```bash
+# Run only specific benchmarks
+bash scripts/run_benchmark.sh softmax
+bash scripts/run_benchmark.sh gemm moe
+bash scripts/run_benchmark.sh --only softmax,layernorm
+```
+
+**Logs:** Written to `${BENCH_LOG_DIR:-/tmp/flir_bench}/`
+
+---
+
+## 3. Pytest Configuration
+
+### 3.1 `tests/conftest.py`
+
+Pytest configuration with MLIR context fixtures.
+
+**Fixtures:**
+
+```python
+@pytest.fixture
+def ctx():
+    """Fresh MLIR context per test with FLIR dialects registered."""
+    # Creates Context, registers FLIR extensions, yields object with:
+    #   ctx.context, ctx.module, ctx.location
+
+@pytest.fixture
+def module(ctx):
+    """Provides ctx.module."""
+
+@pytest.fixture
+def insert_point(ctx):
+    """Sets insertion point to module body."""
+```
+
+**Build discovery:** Supports two build layouts:
+- Preferred: `.flir/build/python_packages/flydsl`
+- Fallback: `build/python_packages/flydsl`
+
+**Session hook:** Prevents pytest exit code 5 (no tests collected) from being treated as failure.
+
+---
+
+## 4. Performance Measurement
+
+### 4.1 `tests/test_common.py`
+
+Core performance testing utilities, adapted from AIter's test infrastructure.
+
+**`perftest()` decorator:**
+```python
+@perftest(num_iters=20, num_warmup=3, testGraph=False, num_rotate_args=0, needTrace=False)
+def my_kernel_test(Input, Output):
+    # Kernel invocation
+    ...
+```
+
+Features:
+- Device memory profiling to determine iteration count
+- Torch CUDA event timing
+- HIPGraph capture mode (`testGraph=True`)
+- Optional tensorboard trace profiling
+- Cache-aware iteration calculation
+
+**`checkAllclose()` function:**
+```python
+checkAllclose(output, reference, rtol=1e-2, atol=1e-2, tol_err_ratio=0.05)
+```
+Returns percent mismatch (0 = pass). Uses colored ANSI output for pass/fail indication.
+
+**`verify_output()` function:**
+```python
+verify_output(c_out, c_ref, atol=1e-2, rtol=1e-2, msg='')
+```
+High-level validation wrapper around `checkAllclose`.
+
+### 4.2 `tests/kernels/benchmark_common.py`
+
+Shared benchmark harness for FLIR vs AIter comparison.
+
+**Key types:**
+```python
+@dataclass(frozen=True)
+class PerfRow:
+    op: str           # e.g., "softmax"
+    shape: str        # e.g., "32768x8192"
+    dtype: str        # e.g., "bf16"
+    flir_gpu_us: Optional[float]
+    aiter_gpu_us: Optional[float]
+
+    @property
+    def speedup_aiter_vs_flir(self) -> Optional[float]:
+        ...  # flir_us / aiter_us
+```
+
+**Key functions:**
+```python
+# Measure device time (torch CUDA events)
+gpu_us = bench_gpu_us_torch(fn, warmup=20, iters=200)
+
+# Enable AIter comparison (best-effort)
+aiter_available = maybe_enable_aiter()  # respects AITER_REPO env var
+
+# Run comparative sweep
+rows = run_compare_sweep(configs=[(M, N, dtype), ...])
+print_perf_table(rows)
+```
+
+**Environment variables:**
+| Variable | Description | Default |
+|---|---|---|
+| `BENCH_CONFIGS` | Override benchmark configs | Default shapes |
+| `BENCH_WARMUP` | Warmup iterations | 10 |
+| `BENCH_ITERS` | Benchmark iterations | 50 |
+| `AITER_REPO` | Path to AIter repo for comparison | Auto-detect |
+
+---
+
+## 5. Writing New Tests
+
+### 5.1 PyIR Test Pattern
+
+```python
+# tests/pyir/test_my_feature.py
+from flydsl.dialects.ext import flir, arith
+from flydsl.lang.ir.module import MlirModule, kernel, jit
+import _mlir.extras.types as T
+
+class _MyTest(MlirModule):
+    GPU_MODULE_NAME = "my_test"
+
+    @jit
+    def my_operation(self):
+        shape = flir.make_shape(4, 8)
+        stride = flir.make_stride(8, 1)
+        layout = flir.make_layout(shape, stride)
+        result = flir.size(layout)
+        return result
+
+def test_my_feature():
+    mod = _MyTest()
+    ir_str = str(mod.module)
+    # Verify IR contains expected operations
+    assert "flir.make_layout" in ir_str
+    assert "flir.size" in ir_str
+```
+
+### 5.2 GPU Kernel Test Pattern
+
+```python
+# tests/kernels/test_my_kernel.py
+import torch
+from tests.utils import compile_to_hsaco
+from tests.test_common import checkAllclose
+
+def test_my_kernel():
+    M, N = 1024, 1024
+    dtype = torch.float16
+
+    # 1. Build kernel
+    from kernels.my_kernel import build_my_module
+    executor = build_my_module(M, N, "f16")
+
+    # 2. Prepare data
+    input_tensor = torch.randn(M, N, dtype=dtype, device="cuda")
+    output_tensor = torch.empty_like(input_tensor)
+
+    # 3. Execute kernel
+    executor(input_tensor, output_tensor, M)
+
+    # 4. Reference
+    reference = torch.nn.functional.layer_norm(input_tensor, [N])
+
+    # 5. Validate
+    err = checkAllclose(output_tensor, reference, rtol=1e-2, atol=1e-2)
+    assert err == 0, f"Mismatch: {err}%"
+```
+
+### 5.3 Benchmark Test Pattern
+
+```python
+# Add to tests/kernels/test_my_kernel.py
+from tests.kernels.benchmark_common import bench_gpu_us_torch
+
+def benchmark_my_kernel():
+    executor = build_my_module(M, N, dtype)
+
+    # Wrap kernel call
+    def run():
+        executor(input_tensor, output_tensor, M)
+
+    # Measure
+    gpu_us = bench_gpu_us_torch(run, warmup=20, iters=200)
+
+    # Compute metrics
+    total_bytes = 2 * M * N * elem_size  # read input + write output
+    bandwidth_tbs = total_bytes / (gpu_us * 1e-6) / 1e12
+    print(f"Time: {gpu_us:.1f} us, Bandwidth: {bandwidth_tbs:.2f} TB/s")
+```
+
+---
+
+## 6. Test Configuration via Environment Variables
+
+| Variable | Used By | Description |
+|---|---|---|
+| `ROCDSL_SOFTMAX_SHAPES` | `test_softmax.py` | Override softmax test shapes (format: `"M,N,dtype;..."`) |
+| `ROCDSL_LAYERNORM_SHAPES` | `test_layernorm.py` | Override layernorm test shapes |
+| `ROCDSL_COMPARE_AITER` | kernel tests | Set to `1` to enable AIter comparison |
+| `FLIR_DUMP_IR` | `tests/utils.py` | Set to `1` to dump intermediate IR |
+| `FLIR_DUMP_DIR` | `tests/utils.py` | IR dump directory (default: `/tmp/flir_dump`) |
+| `FLIR_ENABLE_IR_PRINTING` | `tests/utils.py` | Print IR to console |
+| `FLIR_TIME_COMPILE` | `tests/utils.py` | Print per-stage compilation timing |
+| `FLIR_BUILD_DIR` | `conftest.py` | Override build directory path |
+
+---
+
+## 7. GEMM Test CLI Arguments
+
+The `test_preshuffle_gemm.py` test supports extensive CLI configuration:
+
+```bash
+python tests/kernels/test_preshuffle_gemm.py \
+    --in_dtype fp8 \
+    -M 16 -N 5120 -K 8192 \
+    --tile_m 16 --tile_n 128 --tile_k 256 \
+    --lds_stage 2 \
+    --num_iters 20 \
+    --num_warmup 3 \
+    --no_aiter_bench \
+    --test_graph        # or -tg for HIPGraph mode
+    --wfp4              # W4 (INT4) weight path
+```
+
+---
+
+## 8. Compilation Utilities (`tests/utils.py`)
+
+The `compile_to_hsaco()` function provides a standalone compilation path for tests:
+
+**Pipeline stages:**
+1. `flir-to-standard` lowering
+2. `trivial-dce` (dead code elimination)
+3. `canonicalize`
+4. `cse` (common subexpression elimination)
+5. Attach ROCDL target (auto-detect `gpu_arch`)
+6. `convert-gpu-to-rocdl` (SCF→CF, bare pointer memref)
+7. `gpu-to-llvm`
+8. `lower-to-llvm`
+9. `gpu-module-to-binary`
+
+**Weight utilities:**
+```python
+from tests.utils import pertoken_quant, shuffle_weight
+
+# Per-token quantization (handles NaN/Inf)
+quantized, scales = pertoken_quant(tensor, dtype=torch.float8_e4m3fnuz)
+
+# Weight preshuffle for MFMA (layout 16x16)
+shuffled = shuffle_weight(weight, layout=(16, 16))
+```
+
+---
+
+## 9. Source Files
+
+| File | Description |
+|---|---|
+| `scripts/run_tests.sh` | Main test orchestrator (4 categories) |
+| `scripts/run_benchmark.sh` | Benchmark harness with configurable shapes |
+| `tests/conftest.py` | Pytest fixtures (MLIR context, module, insert point) |
+| `tests/test_common.py` | `perftest()`, `checkAllclose()`, `verify_output()` |
+| `tests/utils.py` | `compile_to_hsaco()`, `pertoken_quant()`, `shuffle_weight()` |
+| `tests/kernels/benchmark_common.py` | `PerfRow`, `bench_gpu_us_torch()`, `print_perf_table()` |
+| `tests/mlir/*.mlir` | MLIR IR lowering tests (22 files) |
+| `tests/pyir/test_*.py` | Python IR generation tests (16 files) |
+| `tests/kernels/test_*.py` | GPU kernel tests (15 files) |
+| `tests/kernels/utils/fp4_utils.py` | FP4 packing/shuffling utilities |

--- a/kernels/flash_attention_v4.py
+++ b/kernels/flash_attention_v4.py
@@ -1,0 +1,539 @@
+"""Flash Attention V4 kernel builder for FlyDSL.
+
+Multi-wave MFMA implementation: 4 waves (256 threads), BLOCK_M=64, BLOCK_N=16.
+Each wave owns 16 Q-rows and performs independent MFMA Q@K^T and P@V.
+All 256 threads cooperate on K/V tile loads.
+
+Inspired by the poc_kl ASM kernel (8w, 256x32, mfma_32x32x8, ping-pong LDS).
+This V4.0 uses mfma_f32_16x16x16f16 with single-buffered K/V as a first step.
+
+V4.0 vs V3.1:
+- 4 waves (256 threads) vs 1 wave (64 threads) → 4x more MFMA throughput per CU
+- BLOCK_M=64 vs 16 → 4x fewer grid workgroups, better scheduling
+- Cooperative load: 256 threads → K/V tile (16×HD) loaded in 1 batch (vs 4)
+- LDS: ~30KB (Q=16KB + KV=4KB + P=2KB)
+
+Layout: Q/K/V/O are 1D flattened from BSHD (batch, seq_len, num_heads, head_dim).
+Grid:   (batch * num_q_tiles * num_heads,) where num_q_tiles = seq_len / BLOCK_M.
+Block:  (256,) — 4 waves of 64 on AMD (wave64).
+
+Requires: head_dim % 16 == 0, seq_len % 64 == 0, head_dim >= 64.
+"""
+
+import math
+
+from flydsl.dialects.ext import flir, arith, gpu, scf, rocdl
+from flydsl.dialects.ext import vector as vec_ext
+from flydsl.dialects.ext.python_control_flow import range_constexpr
+from flydsl.dialects.ext.scf import yield_ as scf_yield
+from _mlir.dialects import memref as _memref
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils import SmemAllocator
+from _mlir import ir
+import _mlir.extras.types as T
+
+
+KERNEL_NAME = "flash_attention_v4_kernel"
+
+
+def build_flash_attention_v4_module(
+    num_heads,
+    head_dim,
+    causal=True,
+    dtype_str="f16",
+    sm_scale=None,
+):
+    """Build a FlyDSL Flash Attention V4 module with multi-wave MFMA tiling.
+
+    Args:
+        num_heads: Number of attention heads.
+        head_dim: Dimension per head (must be divisible by 16, >= 64).
+        causal: Whether to apply causal mask.
+        dtype_str: "f16" (bf16 not yet supported).
+        sm_scale: Softmax scale (default: 1/sqrt(head_dim)).
+
+    Returns:
+        MlirModule compilable via ``flydsl.compile(module)``.
+    """
+    gpu_arch = get_hip_arch()
+    DYN = ir.ShapedType.get_dynamic_size()
+
+    BLOCK_M = 64
+    BLOCK_N = 16
+    NUM_WAVES = 4
+    WARP_SIZE = 64
+    BLOCK_SIZE = NUM_WAVES * WARP_SIZE  # 256
+    ROWS_PER_WAVE = BLOCK_M // NUM_WAVES  # 16
+    K_STEPS = head_dim // 16
+
+    assert head_dim % 16 == 0, f"head_dim ({head_dim}) must be divisible by 16"
+    assert head_dim >= 64, f"head_dim ({head_dim}) must be >= 64"
+    assert dtype_str == "f16", "V4 currently only supports f16"
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    CAUSAL = causal
+    STRIDE_TOKEN = NUM_HEADS * HEAD_DIM
+
+    # ---- Vectorized cooperative load constants ----
+    VEC_WIDTH = 8  # v8f16 = 16 bytes
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    # For Q tile (64 rows): NUM_BATCHES_Q = 64 / ROWS_PER_BATCH
+    assert BLOCK_M % ROWS_PER_BATCH_LOAD == 0
+    NUM_BATCHES_Q = BLOCK_M // ROWS_PER_BATCH_LOAD
+
+    # For KV tile (16 rows): NUM_BATCHES_KV = 16 / ROWS_PER_BATCH
+    assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0 or ROWS_PER_BATCH_LOAD >= BLOCK_N
+    if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+        NUM_BATCHES_KV = 1
+        # Some threads will be idle (load_row >= BLOCK_N). Need guard.
+        KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+    else:
+        NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+        KV_NEEDS_GUARD = False
+
+    allocator = SmemAllocator(None, arch=gpu_arch)
+    _state = {}
+
+    class _FlashAttentionV4(flir.MlirModule):
+        GPU_MODULE_NAME = f"flash_attn_v4_{dtype_str}"
+        GPU_MODULE_TARGETS = [f'#rocdl.target<chip = "{gpu_arch}", abi = "500">']
+
+        def init_gpu_module(self):
+            elem_type = T.f16()
+            _state["elem_type"] = elem_type
+            _state["lds_q"] = allocator.allocate_array(elem_type, BLOCK_M * HEAD_DIM)
+            _state["lds_kv"] = allocator.allocate_array(elem_type, BLOCK_N * HEAD_DIM)
+            _state["lds_p"] = allocator.allocate_array(elem_type, BLOCK_M * BLOCK_N)
+            allocator.finalize()
+
+        @flir.kernel
+        def flash_attention_v4_kernel(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            seq_len: lambda: T.index(),
+        ):
+            compute_type = T.f32()
+            elem_type = _state["elem_type"]
+            fm_fast = flir.arith.FastMathFlags.fast
+
+            v4f16_type = ir.VectorType.get([4], elem_type)
+            v4f32_type = ir.VectorType.get([4], compute_type)
+            v8f16_type = ir.VectorType.get([VEC_WIDTH], elem_type)
+
+            seq_len_v = arith.as_value(seq_len)
+
+            # ---- LDS views ----
+            base_ptr = allocator.get_base()
+            lds_q = _state["lds_q"](base_ptr).get()
+            lds_kv = _state["lds_kv"](base_ptr).get()
+            lds_p = _state["lds_p"](base_ptr).get()
+
+            # ---- Thread / block indices ----
+            block_id = flir.const_index(flir.block_idx("x"))
+            tid = flir.const_index(flir.thread_idx("x"))
+
+            # ---- Wave decomposition ----
+            c_ws = flir.const_index(WARP_SIZE)
+            wave_id = arith.as_value(flir.arith.DivUIOp(tid, c_ws).result)
+            lane = arith.as_value(flir.arith.RemUIOp(tid, c_ws).result)
+
+            # ---- MFMA lane decomposition (within each wave) ----
+            c16 = flir.const_index(16)
+            lane_div_16 = arith.as_value(flir.arith.DivUIOp(lane, c16).result)
+            lane_mod_16 = arith.as_value(flir.arith.RemUIOp(lane, c16).result)
+
+            # ---- Wave's Q-row offset in the Q tile ----
+            wave_q_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE).value
+            # Wave's P offset in lds_p
+            wave_p_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE * BLOCK_N).value
+
+            # ---- Decompose block_id -> (batch_idx, q_tile_idx, head_idx) ----
+            c_nh = flir.const_index(NUM_HEADS)
+            head_idx = arith.as_value(flir.arith.RemUIOp(block_id, c_nh).result)
+            temp = arith.as_value(flir.arith.DivUIOp(block_id, c_nh).result)
+            c_bm = flir.const_index(BLOCK_M)
+            num_q_tiles = arith.as_value(flir.arith.DivUIOp(seq_len_v, c_bm).result)
+            q_tile_idx = arith.as_value(flir.arith.RemUIOp(temp, num_q_tiles).result)
+            batch_idx = arith.as_value(flir.arith.DivUIOp(temp, num_q_tiles).result)
+            q_start = (arith.ArithValue(q_tile_idx) * BLOCK_M).value
+
+            # ---- Vectorized load thread decomposition ----
+            c_tpr = flir.const_index(THREADS_PER_ROW_LOAD)
+            load_row_in_batch = arith.as_value(
+                flir.arith.DivUIOp(tid, c_tpr).result
+            )
+            load_lane_in_row = arith.as_value(
+                flir.arith.RemUIOp(tid, c_tpr).result
+            )
+            load_col_base = (
+                arith.ArithValue(load_lane_in_row) * VEC_WIDTH
+            ).value
+
+            # ---- Helper: global flat index ----
+            def global_idx(token_idx, col):
+                token = (
+                    arith.ArithValue(batch_idx) * arith.ArithValue(seq_len_v)
+                    + arith.ArithValue(token_idx)
+                )
+                return (
+                    token * STRIDE_TOKEN
+                    + arith.ArithValue(head_idx) * HEAD_DIM
+                    + arith.ArithValue(col)
+                ).value
+
+            # ---- Cooperative Q load (64 rows, all 256 threads) ----
+            def coop_load_q():
+                for batch in range_constexpr(NUM_BATCHES_Q):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = (
+                        arith.ArithValue(q_start)
+                        + arith.ArithValue(load_row_in_batch)
+                        + row_offset
+                    ).value
+                    g_idx = global_idx(row_idx, load_col_base)
+                    vec = arith.as_value(
+                        vec_ext.load_op(v8f16_type, Q, [g_idx])
+                    )
+                    lds_row = (
+                        arith.ArithValue(load_row_in_batch) + row_offset
+                    ).value
+                    lds_idx = (
+                        arith.ArithValue(lds_row) * HEAD_DIM
+                        + arith.ArithValue(load_col_base)
+                    ).value
+                    vec_ext.store(vec, lds_q, [lds_idx])
+
+            # ---- Cooperative KV load (16 rows, 256 threads — may need guard) ----
+            def coop_load_kv(src_memref, lds_memref, tile_start):
+                if KV_NEEDS_GUARD:
+                    # With 256 threads and THREADS_PER_ROW=16, ROWS_PER_BATCH=16
+                    # which equals BLOCK_N=16. No guard needed in this config.
+                    # But for safety, handle the case where ROWS_PER_BATCH > BLOCK_N.
+                    c_bn = flir.const_index(BLOCK_N)
+                    row_ok = arith.as_value(
+                        flir.arith.CmpIOp(
+                            flir.arith.CmpIPredicate.ult,
+                            load_row_in_batch, c_bn,
+                        ).result
+                    )
+                    # Only threads with row < BLOCK_N participate
+                    # Use scf.if_ for conditional store
+                    from flydsl.dialects.ext.scf import IfOp
+                    if_op = IfOp(row_ok)
+                    with if_op:
+                        row_idx = (
+                            arith.ArithValue(tile_start)
+                            + arith.ArithValue(load_row_in_batch)
+                        ).value
+                        g_idx = global_idx(row_idx, load_col_base)
+                        vec = arith.as_value(
+                            vec_ext.load_op(v8f16_type, src_memref, [g_idx])
+                        )
+                        lds_idx = (
+                            arith.ArithValue(load_row_in_batch) * HEAD_DIM
+                            + arith.ArithValue(load_col_base)
+                        ).value
+                        vec_ext.store(vec, lds_memref, [lds_idx])
+                else:
+                    for batch in range_constexpr(NUM_BATCHES_KV):
+                        row_offset = batch * ROWS_PER_BATCH_LOAD
+                        row_idx = (
+                            arith.ArithValue(tile_start)
+                            + arith.ArithValue(load_row_in_batch)
+                            + row_offset
+                        ).value
+                        g_idx = global_idx(row_idx, load_col_base)
+                        vec = arith.as_value(
+                            vec_ext.load_op(v8f16_type, src_memref, [g_idx])
+                        )
+                        lds_row = (
+                            arith.ArithValue(load_row_in_batch) + row_offset
+                        ).value
+                        lds_idx = (
+                            arith.ArithValue(lds_row) * HEAD_DIM
+                            + arith.ArithValue(load_col_base)
+                        ).value
+                        vec_ext.store(vec, lds_memref, [lds_idx])
+
+            # ---- Load Q tile to LDS ----
+            coop_load_q()
+            gpu.barrier()
+
+            # ---- Constants ----
+            c_neg_inf = arith.constant(float("-inf"), type=compute_type)
+            c_zero_f = arith.constant(0.0, type=compute_type)
+            c_sm_scale = arith.constant(sm_scale, type=compute_type)
+            c_log2e = arith.constant(1.4426950408889634, type=compute_type)
+            c_zero_v4f32 = arith.as_value(
+                arith.constant_vector(0.0, v4f32_type)
+            )
+
+            # ---- Init loop-carried state ----
+            # [m_0..m_3, l_0..l_3, o_acc_0..o_acc_{K_STEPS-1}]
+            init_args = []
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_neg_inf))
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_zero_f))
+            for _ in range_constexpr(K_STEPS):
+                init_args.append(c_zero_v4f32)
+
+            # ---- KV loop ----
+            with scf.for_(0, seq_len_v, BLOCK_N, iter_args=init_args) as loop:
+                kv_start = arith.as_value(loop.induction_variable)
+                m_old = [arith.as_value(loop.inner_iter_args[i]) for i in range(4)]
+                l_old = [arith.as_value(loop.inner_iter_args[4 + i]) for i in range(4)]
+                o_accs = [arith.as_value(loop.inner_iter_args[8 + ds]) for ds in range(K_STEPS)]
+
+                # ==== Cooperative K load -> LDS_KV ====
+                coop_load_kv(K, lds_kv, kv_start)
+                gpu.barrier()
+
+                # ==== Q @ K^T via MFMA (each wave uses its Q rows) ====
+                s_acc = c_zero_v4f32
+                for ks in range_constexpr(K_STEPS):
+                    # A operand (Q): lane's Q row within this wave's 16 rows
+                    q_lds_idx = (
+                        (arith.ArithValue(wave_q_offset)
+                         + arith.ArithValue(lane_mod_16)) * HEAD_DIM
+                        + ks * 16
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    a_pack = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_q, [q_lds_idx])
+                    )
+                    # B operand (K^T): same for all waves (shared K tile)
+                    k_lds_idx = (
+                        arith.ArithValue(lane_mod_16) * HEAD_DIM
+                        + ks * 16
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    b_pack = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_kv, [k_lds_idx])
+                    )
+                    s_acc = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(v4f32_type, [a_pack, b_pack, s_acc, 0, 0, 0])
+                    )
+
+                # ==== Online softmax (per-wave, per-row) ====
+                s_vals = []
+                for ii in range_constexpr(4):
+                    s_ii = arith.as_value(
+                        vec_ext.extract(s_acc, static_position=[ii], dynamic_position=[])
+                    )
+                    s_ii = arith.as_value(
+                        flir.arith.MulFOp(s_ii, arith.as_value(c_sm_scale), fastmath=fm_fast).result
+                    )
+                    if CAUSAL:
+                        # Global Q row for this lane's ii-th element
+                        q_row = (
+                            arith.ArithValue(q_start)
+                            + arith.ArithValue(wave_q_offset)
+                            + arith.ArithValue(lane_div_16) * 4
+                            + ii
+                        ).value
+                        kv_col = (arith.ArithValue(kv_start) + arith.ArithValue(lane_mod_16)).value
+                        q_row_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), q_row).result)
+                        kv_col_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), kv_col).result)
+                        is_masked = arith.as_value(
+                            flir.arith.CmpIOp(
+                                flir.arith.CmpIPredicate.ugt, kv_col_i64, q_row_i64,
+                            ).result
+                        )
+                        s_ii = arith.as_value(
+                            flir.arith.SelectOp(is_masked, arith.as_value(c_neg_inf), s_ii).result
+                        )
+                    s_vals.append(s_ii)
+
+                width_i32 = arith.as_value(arith.constant(WARP_SIZE, type=T.i32()))
+                m_new = [None] * 4
+                corr = [None] * 4
+                p_vals = [None] * 4
+                l_new = [None] * 4
+
+                for ii in range_constexpr(4):
+                    row_max = s_vals[ii]
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_max, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_max = arith.as_value(
+                            flir.arith.MaximumFOp(row_max, peer).result
+                        )
+
+                    m_new[ii] = arith.as_value(
+                        flir.arith.MaximumFOp(m_old[ii], row_max).result
+                    )
+
+                    diff_m = arith.as_value(
+                        flir.arith.SubFOp(m_old[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_m_s = arith.as_value(
+                        flir.arith.MulFOp(diff_m, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    corr[ii] = arith.as_value(flir.math.exp2(diff_m_s, fastmath=fm_fast))
+
+                    diff_s = arith.as_value(
+                        flir.arith.SubFOp(s_vals[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_s_s = arith.as_value(
+                        flir.arith.MulFOp(diff_s, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    p_vals[ii] = arith.as_value(flir.math.exp2(diff_s_s, fastmath=fm_fast))
+
+                    row_sum = p_vals[ii]
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_sum, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_sum = arith.as_value(
+                            flir.arith.AddFOp(row_sum, peer, fastmath=fm_fast).result
+                        )
+
+                    l_corr = arith.as_value(
+                        flir.arith.MulFOp(corr[ii], l_old[ii], fastmath=fm_fast).result
+                    )
+                    l_new[ii] = arith.as_value(
+                        flir.arith.AddFOp(l_corr, row_sum, fastmath=fm_fast).result
+                    )
+
+                # ==== Rescale O accumulators ====
+                corr_vec = arith.as_value(
+                    vec_ext.from_elements(v4f32_type, [corr[0], corr[1], corr[2], corr[3]])
+                )
+                for ds in range_constexpr(K_STEPS):
+                    o_accs[ds] = arith.as_value(
+                        flir.arith.MulFOp(o_accs[ds], corr_vec, fastmath=fm_fast).result
+                    )
+
+                # ==== P store to LDS_P (each wave writes its 16×16 section) ====
+                for ii in range_constexpr(4):
+                    p_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, p_vals[ii]).result
+                    )
+                    p_row = (arith.ArithValue(lane_div_16) * 4 + ii).value
+                    p_lds_idx = (
+                        arith.ArithValue(wave_p_offset)
+                        + arith.ArithValue(p_row) * BLOCK_N
+                        + arith.ArithValue(lane_mod_16)
+                    ).value
+                    _memref.StoreOp(p_f16, lds_p, [p_lds_idx])
+
+                # ==== Barrier: ensure all waves finished reading K from lds_kv ====
+                gpu.barrier()
+
+                # ==== Cooperative V load -> LDS_KV (overwrites K) ====
+                coop_load_kv(V, lds_kv, kv_start)
+                gpu.barrier()
+
+                # ==== P load (A-operand, wave-local) ====
+                p_a_idx = (
+                    arith.ArithValue(wave_p_offset)
+                    + arith.ArithValue(lane_mod_16) * BLOCK_N
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                p_pack = arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_p, [p_a_idx])
+                )
+
+                # ==== P @ V via MFMA ====
+                for ds in range_constexpr(K_STEPS):
+                    v_elems = []
+                    for e in range_constexpr(4):
+                        v_row = (arith.ArithValue(lane_div_16) * 4 + e).value
+                        v_lds_idx = (
+                            arith.ArithValue(v_row) * HEAD_DIM
+                            + ds * 16
+                            + arith.ArithValue(lane_mod_16)
+                        ).value
+                        v_val = _memref.LoadOp(lds_kv, [v_lds_idx]).result
+                        v_elems.append(arith.as_value(v_val))
+                    v_pack = arith.as_value(
+                        vec_ext.from_elements(v4f16_type, v_elems)
+                    )
+                    o_accs[ds] = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(
+                            v4f32_type, [p_pack, v_pack, o_accs[ds], 0, 0, 0]
+                        )
+                    )
+
+                # ==== Barrier: ensure all waves finished P@V (reading lds_kv)
+                #       before next iteration overwrites lds_kv with K ====
+                gpu.barrier()
+
+                # ==== Yield ====
+                yield_args = m_new + l_new + o_accs
+                scf_yield(yield_args)
+
+            # ---- Normalize and store O ----
+            m_finals = [arith.as_value(loop.results[i]) for i in range(4)]
+            l_finals = [arith.as_value(loop.results[4 + i]) for i in range(4)]
+            o_finals = [arith.as_value(loop.results[8 + ds]) for ds in range(K_STEPS)]
+
+            for ds in range_constexpr(K_STEPS):
+                for ii in range_constexpr(4):
+                    o_val = arith.as_value(
+                        vec_ext.extract(o_finals[ds], static_position=[ii], dynamic_position=[])
+                    )
+                    o_norm = arith.as_value(
+                        flir.arith.DivFOp(o_val, l_finals[ii], fastmath=fm_fast).result
+                    )
+                    o_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, o_norm).result
+                    )
+                    # Global store: each wave writes its Q rows
+                    q_row = (
+                        arith.ArithValue(q_start)
+                        + arith.ArithValue(wave_q_offset)
+                        + arith.ArithValue(lane_div_16) * 4
+                        + ii
+                    ).value
+                    d_col = (flir.const_index(ds * 16) + arith.ArithValue(lane_mod_16)).value
+                    o_global = global_idx(q_row, d_col)
+                    _memref.StoreOp(o_f16, O, [o_global])
+
+        @flir.jit
+        def __call__(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            batch_size: lambda: T.index(),
+            seq_len: lambda: T.index(),
+        ):
+            c1 = arith.as_value(flir.arith_ext.index(1))
+            c_nh = arith.as_value(flir.arith_ext.index(NUM_HEADS))
+            c_bm = arith.as_value(flir.arith_ext.index(BLOCK_M))
+            bs_val = arith.as_value(batch_size)
+            sl_val = arith.as_value(seq_len)
+            num_q_tiles = arith.as_value(
+                flir.arith.DivUIOp(sl_val, c_bm).result
+            )
+            bs_qt = arith.as_value(
+                flir.arith.MulIOp(bs_val, num_q_tiles).result
+            )
+            grid_x = arith.as_value(
+                flir.arith.MulIOp(bs_qt, c_nh).result
+            )
+            bx = arith.as_value(flir.arith_ext.index(BLOCK_SIZE))
+            flir.gpu_ext.LaunchFuncOp(
+                [self.GPU_MODULE_NAME, KERNEL_NAME],
+                grid_size=(grid_x, c1, c1),
+                block_size=(bx, c1, c1),
+                kernel_operands=[Q, K, V, O, seq_len],
+            )
+
+    return _FlashAttentionV4()

--- a/kernels/flash_attention_v4_1.py
+++ b/kernels/flash_attention_v4_1.py
@@ -1,0 +1,612 @@
+"""Flash Attention V4.1 kernel builder for FlyDSL.
+
+V4.1 optimizations over V4.0:
+- Q preloaded to registers (eliminates Q LDS reads from KV loop)
+- V stored transposed in LDS (vectorized v4f16 B-operand loads)
+- Bank-conflict-free LDS padding (K stride=HD+2, V transposed stride=BLOCK_N+2)
+
+Tile config: BLOCK_M=64, BLOCK_N=16, 4 waves (256 threads), mfma_f32_16x16x16f16.
+
+Expected improvements from V4.0:
+- ~32% fewer LDS instructions (Q reads eliminated, V loads vectorized)
+- Reduced LDS bank conflicts
+
+Layout: Q/K/V/O are 1D flattened from BSHD (batch, seq_len, num_heads, head_dim).
+Grid:   (batch * num_q_tiles * num_heads,) where num_q_tiles = seq_len / BLOCK_M.
+Block:  (256,) -- 4 waves of 64 on AMD (wave64).
+
+Requires: head_dim % 16 == 0, seq_len % 64 == 0, head_dim >= 64.
+"""
+
+import math
+
+from flydsl.dialects.ext import flir, arith, gpu, scf, rocdl
+from flydsl.dialects.ext import vector as vec_ext
+from flydsl.dialects.ext.python_control_flow import range_constexpr
+from flydsl.dialects.ext.scf import yield_ as scf_yield
+from _mlir.dialects import memref as _memref
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils import SmemAllocator
+from _mlir import ir
+import _mlir.extras.types as T
+
+
+KERNEL_NAME = "flash_attention_v4_1_kernel"
+
+
+def build_flash_attention_v4_1_module(
+    num_heads,
+    head_dim,
+    causal=True,
+    dtype_str="f16",
+    sm_scale=None,
+):
+    """Build a FlyDSL Flash Attention V4.1 module.
+
+    Args:
+        num_heads: Number of attention heads.
+        head_dim: Dimension per head (must be divisible by 16, >= 64).
+        causal: Whether to apply causal mask.
+        dtype_str: "f16" (bf16 not yet supported).
+        sm_scale: Softmax scale (default: 1/sqrt(head_dim)).
+
+    Returns:
+        MlirModule compilable via ``flydsl.compile(module)``.
+    """
+    gpu_arch = get_hip_arch()
+    DYN = ir.ShapedType.get_dynamic_size()
+
+    BLOCK_M = 64
+    BLOCK_N = 16
+    NUM_WAVES = 4
+    WARP_SIZE = 64
+    BLOCK_SIZE = NUM_WAVES * WARP_SIZE  # 256
+    ROWS_PER_WAVE = BLOCK_M // NUM_WAVES  # 16
+    K_STEPS = head_dim // 16
+
+    assert head_dim % 16 == 0, f"head_dim ({head_dim}) must be divisible by 16"
+    assert head_dim >= 64, f"head_dim ({head_dim}) must be >= 64"
+    assert dtype_str == "f16", "V4.1 currently only supports f16"
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    CAUSAL = causal
+    STRIDE_TOKEN = NUM_HEADS * HEAD_DIM
+
+    # ---- Bank-conflict-free LDS strides ----
+    # K row-major: stride = HD + 2 (makes row stride odd in bank units)
+    # V transposed: stride = BLOCK_N + 2 (same reasoning)
+    K_STRIDE = HEAD_DIM + 2   # 130 for HD=128
+    VT_STRIDE = BLOCK_N + 2   # 18 for BLOCK_N=16
+
+    # ---- Vectorized cooperative load constants ----
+    VEC_WIDTH = 8  # v8f16 = 16 bytes
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    # For Q tile (64 rows)
+    assert BLOCK_M % ROWS_PER_BATCH_LOAD == 0
+    NUM_BATCHES_Q = BLOCK_M // ROWS_PER_BATCH_LOAD
+
+    # For KV tile (16 rows)
+    assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0 or ROWS_PER_BATCH_LOAD >= BLOCK_N
+    if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+        NUM_BATCHES_KV = 1
+        KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+    else:
+        NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+        KV_NEEDS_GUARD = False
+
+    # LDS sizes
+    LDS_Q_SIZE = BLOCK_M * HEAD_DIM  # Q unpadded (only read once for register preload)
+    LDS_KV_SIZE = max(BLOCK_N * K_STRIDE, HEAD_DIM * VT_STRIDE)  # max(K padded, Vt padded)
+    LDS_P_SIZE = BLOCK_M * BLOCK_N
+
+    allocator = SmemAllocator(None, arch=gpu_arch)
+    _state = {}
+
+    class _FlashAttentionV4_1(flir.MlirModule):
+        GPU_MODULE_NAME = f"flash_attn_v4_1_{dtype_str}"
+        GPU_MODULE_TARGETS = [f'#rocdl.target<chip = "{gpu_arch}", abi = "500">']
+
+        def init_gpu_module(self):
+            elem_type = T.f16()
+            _state["elem_type"] = elem_type
+            _state["lds_q"] = allocator.allocate_array(elem_type, LDS_Q_SIZE)
+            _state["lds_kv"] = allocator.allocate_array(elem_type, LDS_KV_SIZE)
+            _state["lds_p"] = allocator.allocate_array(elem_type, LDS_P_SIZE)
+            allocator.finalize()
+
+        @flir.kernel
+        def flash_attention_v4_1_kernel(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            seq_len: lambda: T.index(),
+        ):
+            compute_type = T.f32()
+            elem_type = _state["elem_type"]
+            fm_fast = flir.arith.FastMathFlags.fast
+
+            v4f16_type = ir.VectorType.get([4], elem_type)
+            v4f32_type = ir.VectorType.get([4], compute_type)
+            v8f16_type = ir.VectorType.get([VEC_WIDTH], elem_type)
+
+            seq_len_v = arith.as_value(seq_len)
+
+            # ---- LDS views ----
+            base_ptr = allocator.get_base()
+            lds_q = _state["lds_q"](base_ptr).get()
+            lds_kv = _state["lds_kv"](base_ptr).get()
+            lds_p = _state["lds_p"](base_ptr).get()
+
+            # ---- Thread / block indices ----
+            block_id = flir.const_index(flir.block_idx("x"))
+            tid = flir.const_index(flir.thread_idx("x"))
+
+            # ---- Wave decomposition ----
+            c_ws = flir.const_index(WARP_SIZE)
+            wave_id = arith.as_value(flir.arith.DivUIOp(tid, c_ws).result)
+            lane = arith.as_value(flir.arith.RemUIOp(tid, c_ws).result)
+
+            # ---- MFMA lane decomposition (within each wave) ----
+            c16 = flir.const_index(16)
+            lane_div_16 = arith.as_value(flir.arith.DivUIOp(lane, c16).result)
+            lane_mod_16 = arith.as_value(flir.arith.RemUIOp(lane, c16).result)
+
+            # ---- Wave's Q-row offset in the Q tile ----
+            wave_q_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE).value
+            # Wave's P offset in lds_p
+            wave_p_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE * BLOCK_N).value
+
+            # ---- Decompose block_id -> (batch_idx, q_tile_idx, head_idx) ----
+            c_nh = flir.const_index(NUM_HEADS)
+            head_idx = arith.as_value(flir.arith.RemUIOp(block_id, c_nh).result)
+            temp = arith.as_value(flir.arith.DivUIOp(block_id, c_nh).result)
+            c_bm = flir.const_index(BLOCK_M)
+            num_q_tiles = arith.as_value(flir.arith.DivUIOp(seq_len_v, c_bm).result)
+            q_tile_idx = arith.as_value(flir.arith.RemUIOp(temp, num_q_tiles).result)
+            batch_idx = arith.as_value(flir.arith.DivUIOp(temp, num_q_tiles).result)
+            q_start = (arith.ArithValue(q_tile_idx) * BLOCK_M).value
+
+            # ---- Vectorized load thread decomposition ----
+            c_tpr = flir.const_index(THREADS_PER_ROW_LOAD)
+            load_row_in_batch = arith.as_value(
+                flir.arith.DivUIOp(tid, c_tpr).result
+            )
+            load_lane_in_row = arith.as_value(
+                flir.arith.RemUIOp(tid, c_tpr).result
+            )
+            load_col_base = (
+                arith.ArithValue(load_lane_in_row) * VEC_WIDTH
+            ).value
+
+            # ---- Helper: global flat index ----
+            def global_idx(token_idx, col):
+                token = (
+                    arith.ArithValue(batch_idx) * arith.ArithValue(seq_len_v)
+                    + arith.ArithValue(token_idx)
+                )
+                return (
+                    token * STRIDE_TOKEN
+                    + arith.ArithValue(head_idx) * HEAD_DIM
+                    + arith.ArithValue(col)
+                ).value
+
+            # ---- Cooperative Q load (64 rows, all 256 threads, unpadded) ----
+            def coop_load_q():
+                for batch in range_constexpr(NUM_BATCHES_Q):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = (
+                        arith.ArithValue(q_start)
+                        + arith.ArithValue(load_row_in_batch)
+                        + row_offset
+                    ).value
+                    g_idx = global_idx(row_idx, load_col_base)
+                    vec = arith.as_value(
+                        vec_ext.load_op(v8f16_type, Q, [g_idx])
+                    )
+                    lds_row = (
+                        arith.ArithValue(load_row_in_batch) + row_offset
+                    ).value
+                    lds_idx = (
+                        arith.ArithValue(lds_row) * HEAD_DIM
+                        + arith.ArithValue(load_col_base)
+                    ).value
+                    vec_ext.store(vec, lds_q, [lds_idx])
+
+            # ---- Cooperative K load (row-major with padded stride) ----
+            def coop_load_k(tile_start):
+                if KV_NEEDS_GUARD:
+                    c_bn = flir.const_index(BLOCK_N)
+                    row_ok = arith.as_value(
+                        flir.arith.CmpIOp(
+                            flir.arith.CmpIPredicate.ult,
+                            load_row_in_batch, c_bn,
+                        ).result
+                    )
+                    from flydsl.dialects.ext.scf import IfOp
+                    if_op = IfOp(row_ok)
+                    with if_op:
+                        row_idx = (
+                            arith.ArithValue(tile_start)
+                            + arith.ArithValue(load_row_in_batch)
+                        ).value
+                        g_idx = global_idx(row_idx, load_col_base)
+                        vec = arith.as_value(
+                            vec_ext.load_op(v8f16_type, K, [g_idx])
+                        )
+                        lds_idx = (
+                            arith.ArithValue(load_row_in_batch) * K_STRIDE
+                            + arith.ArithValue(load_col_base)
+                        ).value
+                        vec_ext.store(vec, lds_kv, [lds_idx])
+                else:
+                    for batch in range_constexpr(NUM_BATCHES_KV):
+                        row_offset = batch * ROWS_PER_BATCH_LOAD
+                        row_idx = (
+                            arith.ArithValue(tile_start)
+                            + arith.ArithValue(load_row_in_batch)
+                            + row_offset
+                        ).value
+                        g_idx = global_idx(row_idx, load_col_base)
+                        vec = arith.as_value(
+                            vec_ext.load_op(v8f16_type, K, [g_idx])
+                        )
+                        lds_row = (
+                            arith.ArithValue(load_row_in_batch) + row_offset
+                        ).value
+                        lds_idx = (
+                            arith.ArithValue(lds_row) * K_STRIDE
+                            + arith.ArithValue(load_col_base)
+                        ).value
+                        vec_ext.store(vec, lds_kv, [lds_idx])
+
+            # ---- Cooperative V load (transposed with padded stride) ----
+            # Global V[row, col] -> LDS Vt[col, row] at lds_kv[col * VT_STRIDE + row]
+            def coop_load_v_transposed(tile_start):
+                if KV_NEEDS_GUARD:
+                    c_bn = flir.const_index(BLOCK_N)
+                    row_ok = arith.as_value(
+                        flir.arith.CmpIOp(
+                            flir.arith.CmpIPredicate.ult,
+                            load_row_in_batch, c_bn,
+                        ).result
+                    )
+                    from flydsl.dialects.ext.scf import IfOp
+                    if_op = IfOp(row_ok)
+                    with if_op:
+                        row_idx = (
+                            arith.ArithValue(tile_start)
+                            + arith.ArithValue(load_row_in_batch)
+                        ).value
+                        g_idx = global_idx(row_idx, load_col_base)
+                        vec = arith.as_value(
+                            vec_ext.load_op(v8f16_type, V, [g_idx])
+                        )
+                        # Scatter-store transposed: V[row, col+e] -> lds[col_e * VT_STRIDE + row]
+                        for e in range_constexpr(VEC_WIDTH):
+                            elem = arith.as_value(
+                                vec_ext.extract(vec, static_position=[e], dynamic_position=[])
+                            )
+                            col_e = (arith.ArithValue(load_col_base) + e).value
+                            lds_idx = (
+                                arith.ArithValue(col_e) * VT_STRIDE
+                                + arith.ArithValue(load_row_in_batch)
+                            ).value
+                            _memref.StoreOp(elem, lds_kv, [lds_idx])
+                else:
+                    for batch in range_constexpr(NUM_BATCHES_KV):
+                        row_offset = batch * ROWS_PER_BATCH_LOAD
+                        row_idx = (
+                            arith.ArithValue(tile_start)
+                            + arith.ArithValue(load_row_in_batch)
+                            + row_offset
+                        ).value
+                        g_idx = global_idx(row_idx, load_col_base)
+                        vec = arith.as_value(
+                            vec_ext.load_op(v8f16_type, V, [g_idx])
+                        )
+                        load_row = (
+                            arith.ArithValue(load_row_in_batch) + row_offset
+                        ).value
+                        # Scatter-store transposed
+                        for e in range_constexpr(VEC_WIDTH):
+                            elem = arith.as_value(
+                                vec_ext.extract(vec, static_position=[e], dynamic_position=[])
+                            )
+                            col_e = (arith.ArithValue(load_col_base) + e).value
+                            lds_idx = (
+                                arith.ArithValue(col_e) * VT_STRIDE
+                                + arith.ArithValue(load_row)
+                            ).value
+                            _memref.StoreOp(elem, lds_kv, [lds_idx])
+
+            # ---- Load Q tile to LDS ----
+            coop_load_q()
+            gpu.barrier()
+
+            # ---- Preload Q A-operand packs into registers ----
+            # Each lane loads K_STEPS v4f16 packs from LDS_Q (one-time cost).
+            # At step ks, thread (b,n) needs Q[wave_row + n, ks*16 + b*4 : ks*16+b*4+4]
+            q_a_packs = []
+            for ks in range_constexpr(K_STEPS):
+                q_lds_idx = (
+                    (arith.ArithValue(wave_q_offset)
+                     + arith.ArithValue(lane_mod_16)) * HEAD_DIM
+                    + ks * 16
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                q_a_packs.append(arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_q, [q_lds_idx])
+                ))
+
+            # ---- Constants ----
+            c_neg_inf = arith.constant(float("-inf"), type=compute_type)
+            c_zero_f = arith.constant(0.0, type=compute_type)
+            c_sm_scale = arith.constant(sm_scale, type=compute_type)
+            c_log2e = arith.constant(1.4426950408889634, type=compute_type)
+            c_zero_v4f32 = arith.as_value(
+                arith.constant_vector(0.0, v4f32_type)
+            )
+
+            # ---- Init loop-carried state ----
+            # [m_0..m_3, l_0..l_3, o_acc_0..o_acc_{K_STEPS-1}]
+            init_args = []
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_neg_inf))
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_zero_f))
+            for _ in range_constexpr(K_STEPS):
+                init_args.append(c_zero_v4f32)
+
+            # ---- KV loop upper bound ----
+            # Causal early-exit: last Q row = q_start + BLOCK_M - 1,
+            # so only need KV positions 0 .. q_start + BLOCK_M - 1.
+            if CAUSAL:
+                kv_upper = (arith.ArithValue(q_start) + BLOCK_M).value
+            else:
+                kv_upper = seq_len_v
+
+            # ---- KV loop ----
+            with scf.for_(0, kv_upper, BLOCK_N, iter_args=init_args) as loop:
+                kv_start = arith.as_value(loop.induction_variable)
+                m_old = [arith.as_value(loop.inner_iter_args[i]) for i in range(4)]
+                l_old = [arith.as_value(loop.inner_iter_args[4 + i]) for i in range(4)]
+                o_accs = [arith.as_value(loop.inner_iter_args[8 + ds]) for ds in range(K_STEPS)]
+
+                # ==== Cooperative K load -> LDS_KV (row-major, padded stride) ====
+                coop_load_k(kv_start)
+                gpu.barrier()
+
+                # ==== Q @ K^T via MFMA (Q from registers, K from LDS) ====
+                s_acc = c_zero_v4f32
+                for ks in range_constexpr(K_STEPS):
+                    # A operand (Q): from preloaded registers
+                    a_pack = q_a_packs[ks]
+                    # B operand (K^T): from LDS with padded stride
+                    k_lds_idx = (
+                        arith.ArithValue(lane_mod_16) * K_STRIDE
+                        + ks * 16
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    b_pack = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_kv, [k_lds_idx])
+                    )
+                    s_acc = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(v4f32_type, [a_pack, b_pack, s_acc, 0, 0, 0])
+                    )
+
+                # ==== Online softmax (per-wave, per-row) ====
+                s_vals = []
+                for ii in range_constexpr(4):
+                    s_ii = arith.as_value(
+                        vec_ext.extract(s_acc, static_position=[ii], dynamic_position=[])
+                    )
+                    s_ii = arith.as_value(
+                        flir.arith.MulFOp(s_ii, arith.as_value(c_sm_scale), fastmath=fm_fast).result
+                    )
+                    if CAUSAL:
+                        q_row = (
+                            arith.ArithValue(q_start)
+                            + arith.ArithValue(wave_q_offset)
+                            + arith.ArithValue(lane_div_16) * 4
+                            + ii
+                        ).value
+                        kv_col = (arith.ArithValue(kv_start) + arith.ArithValue(lane_mod_16)).value
+                        q_row_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), q_row).result)
+                        kv_col_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), kv_col).result)
+                        is_masked = arith.as_value(
+                            flir.arith.CmpIOp(
+                                flir.arith.CmpIPredicate.ugt, kv_col_i64, q_row_i64,
+                            ).result
+                        )
+                        s_ii = arith.as_value(
+                            flir.arith.SelectOp(is_masked, arith.as_value(c_neg_inf), s_ii).result
+                        )
+                    s_vals.append(s_ii)
+
+                width_i32 = arith.as_value(arith.constant(WARP_SIZE, type=T.i32()))
+                m_new = [None] * 4
+                corr = [None] * 4
+                p_vals = [None] * 4
+                l_new = [None] * 4
+
+                for ii in range_constexpr(4):
+                    row_max = s_vals[ii]
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_max, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_max = arith.as_value(
+                            flir.arith.MaximumFOp(row_max, peer).result
+                        )
+
+                    m_new[ii] = arith.as_value(
+                        flir.arith.MaximumFOp(m_old[ii], row_max).result
+                    )
+
+                    diff_m = arith.as_value(
+                        flir.arith.SubFOp(m_old[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_m_s = arith.as_value(
+                        flir.arith.MulFOp(diff_m, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    corr[ii] = arith.as_value(flir.math.exp2(diff_m_s, fastmath=fm_fast))
+
+                    diff_s = arith.as_value(
+                        flir.arith.SubFOp(s_vals[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_s_s = arith.as_value(
+                        flir.arith.MulFOp(diff_s, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    p_vals[ii] = arith.as_value(flir.math.exp2(diff_s_s, fastmath=fm_fast))
+
+                    row_sum = p_vals[ii]
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_sum, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_sum = arith.as_value(
+                            flir.arith.AddFOp(row_sum, peer, fastmath=fm_fast).result
+                        )
+
+                    l_corr = arith.as_value(
+                        flir.arith.MulFOp(corr[ii], l_old[ii], fastmath=fm_fast).result
+                    )
+                    l_new[ii] = arith.as_value(
+                        flir.arith.AddFOp(l_corr, row_sum, fastmath=fm_fast).result
+                    )
+
+                # ==== Rescale O accumulators ====
+                corr_vec = arith.as_value(
+                    vec_ext.from_elements(v4f32_type, [corr[0], corr[1], corr[2], corr[3]])
+                )
+                for ds in range_constexpr(K_STEPS):
+                    o_accs[ds] = arith.as_value(
+                        flir.arith.MulFOp(o_accs[ds], corr_vec, fastmath=fm_fast).result
+                    )
+
+                # ==== P store to LDS_P (each wave writes its 16x16 section) ====
+                for ii in range_constexpr(4):
+                    p_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, p_vals[ii]).result
+                    )
+                    p_row = (arith.ArithValue(lane_div_16) * 4 + ii).value
+                    p_lds_idx = (
+                        arith.ArithValue(wave_p_offset)
+                        + arith.ArithValue(p_row) * BLOCK_N
+                        + arith.ArithValue(lane_mod_16)
+                    ).value
+                    _memref.StoreOp(p_f16, lds_p, [p_lds_idx])
+
+                # ==== Barrier: ensure all waves finished reading K from lds_kv ====
+                gpu.barrier()
+
+                # ==== Cooperative V load -> LDS_KV (transposed, padded stride) ====
+                coop_load_v_transposed(kv_start)
+                gpu.barrier()
+
+                # ==== P load (A-operand, wave-local) ====
+                p_a_idx = (
+                    arith.ArithValue(wave_p_offset)
+                    + arith.ArithValue(lane_mod_16) * BLOCK_N
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                p_pack = arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_p, [p_a_idx])
+                )
+
+                # ==== P @ V via MFMA (V from transposed LDS, vectorized v4f16 loads) ====
+                # V transposed: V[row, col] at lds_kv[col * VT_STRIDE + row]
+                # B-operand: V[b*4:b*4+4, ds*16+n] = lds_kv[(ds*16+n) * VT_STRIDE + b*4]
+                # -> v4f16 at base (ds*16 + lane_mod_16) * VT_STRIDE + lane_div_16 * 4
+                for ds in range_constexpr(K_STEPS):
+                    v_lds_idx = (
+                        (ds * 16 + arith.ArithValue(lane_mod_16)) * VT_STRIDE
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    v_pack = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_kv, [v_lds_idx])
+                    )
+                    o_accs[ds] = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(
+                            v4f32_type, [p_pack, v_pack, o_accs[ds], 0, 0, 0]
+                        )
+                    )
+
+                # ==== Barrier: ensure all waves finished P@V (reading lds_kv)
+                #       before next iteration overwrites lds_kv with K ====
+                gpu.barrier()
+
+                # ==== Yield ====
+                yield_args = m_new + l_new + o_accs
+                scf_yield(yield_args)
+
+            # ---- Normalize and store O ----
+            m_finals = [arith.as_value(loop.results[i]) for i in range(4)]
+            l_finals = [arith.as_value(loop.results[4 + i]) for i in range(4)]
+            o_finals = [arith.as_value(loop.results[8 + ds]) for ds in range(K_STEPS)]
+
+            for ds in range_constexpr(K_STEPS):
+                for ii in range_constexpr(4):
+                    o_val = arith.as_value(
+                        vec_ext.extract(o_finals[ds], static_position=[ii], dynamic_position=[])
+                    )
+                    o_norm = arith.as_value(
+                        flir.arith.DivFOp(o_val, l_finals[ii], fastmath=fm_fast).result
+                    )
+                    o_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, o_norm).result
+                    )
+                    q_row = (
+                        arith.ArithValue(q_start)
+                        + arith.ArithValue(wave_q_offset)
+                        + arith.ArithValue(lane_div_16) * 4
+                        + ii
+                    ).value
+                    d_col = (flir.const_index(ds * 16) + arith.ArithValue(lane_mod_16)).value
+                    o_global = global_idx(q_row, d_col)
+                    _memref.StoreOp(o_f16, O, [o_global])
+
+        @flir.jit
+        def __call__(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            batch_size: lambda: T.index(),
+            seq_len: lambda: T.index(),
+        ):
+            c1 = arith.as_value(flir.arith_ext.index(1))
+            c_nh = arith.as_value(flir.arith_ext.index(NUM_HEADS))
+            c_bm = arith.as_value(flir.arith_ext.index(BLOCK_M))
+            bs_val = arith.as_value(batch_size)
+            sl_val = arith.as_value(seq_len)
+            num_q_tiles = arith.as_value(
+                flir.arith.DivUIOp(sl_val, c_bm).result
+            )
+            bs_qt = arith.as_value(
+                flir.arith.MulIOp(bs_val, num_q_tiles).result
+            )
+            grid_x = arith.as_value(
+                flir.arith.MulIOp(bs_qt, c_nh).result
+            )
+            bx = arith.as_value(flir.arith_ext.index(BLOCK_SIZE))
+            flir.gpu_ext.LaunchFuncOp(
+                [self.GPU_MODULE_NAME, KERNEL_NAME],
+                grid_size=(grid_x, c1, c1),
+                block_size=(bx, c1, c1),
+                kernel_operands=[Q, K, V, O, seq_len],
+            )
+
+    return _FlashAttentionV4_1()

--- a/kernels/flash_attention_v4_2.py
+++ b/kernels/flash_attention_v4_2.py
@@ -1,0 +1,667 @@
+"""Flash Attention V4.2 kernel builder for FlyDSL.
+
+V4.2 optimizations over V4.1:
+- BLOCK_N=32 (vs 16): halves KV iterations and barriers
+- Q@K^T produces [16,32] via two MFMA 16x16x16 in N dimension
+- P@V uses K=32 via two MFMA 16x16x16 in K dimension
+- Softmax over 32 positions per row (two 16-wide groups)
+- V stored transposed in LDS with bank-conflict-free padding (from V4.1)
+- Q preloaded to registers (from V4.1)
+
+Tile config: BLOCK_M=64, BLOCK_N=32, 4 waves (256 threads), mfma_f32_16x16x16f16.
+
+Layout: Q/K/V/O are 1D flattened from BSHD (batch, seq_len, num_heads, head_dim).
+Grid:   (batch * num_q_tiles * num_heads,) where num_q_tiles = seq_len / BLOCK_M.
+Block:  (256,) -- 4 waves of 64 on AMD (wave64).
+
+Requires: head_dim % 16 == 0, seq_len % 64 == 0, head_dim >= 64.
+"""
+
+import math
+
+from flydsl.dialects.ext import flir, arith, gpu, scf, rocdl
+from flydsl.dialects.ext import vector as vec_ext
+from flydsl.dialects.ext.python_control_flow import range_constexpr
+from flydsl.dialects.ext.scf import yield_ as scf_yield
+from _mlir.dialects import memref as _memref
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils import SmemAllocator
+from _mlir import ir
+import _mlir.extras.types as T
+
+
+KERNEL_NAME = "flash_attention_v4_2_kernel"
+
+
+def build_flash_attention_v4_2_module(
+    num_heads,
+    head_dim,
+    causal=True,
+    dtype_str="f16",
+    sm_scale=None,
+):
+    """Build a FlyDSL Flash Attention V4.2 module.
+
+    Args:
+        num_heads: Number of attention heads.
+        head_dim: Dimension per head (must be divisible by 16, >= 64).
+        causal: Whether to apply causal mask.
+        dtype_str: "f16" (bf16 not yet supported).
+        sm_scale: Softmax scale (default: 1/sqrt(head_dim)).
+
+    Returns:
+        MlirModule compilable via ``flydsl.compile(module)``.
+    """
+    gpu_arch = get_hip_arch()
+    DYN = ir.ShapedType.get_dynamic_size()
+
+    BLOCK_M = 64
+    BLOCK_N = 32   # *** doubled from V4.1 ***
+    NUM_WAVES = 4
+    WARP_SIZE = 64
+    BLOCK_SIZE = NUM_WAVES * WARP_SIZE  # 256
+    ROWS_PER_WAVE = BLOCK_M // NUM_WAVES  # 16
+    K_STEPS = head_dim // 16
+    # Number of 16-wide MFMA columns in Q@K^T N-dimension
+    N_MFMA = BLOCK_N // 16  # 2
+
+    assert head_dim % 16 == 0, f"head_dim ({head_dim}) must be divisible by 16"
+    assert head_dim >= 64, f"head_dim ({head_dim}) must be >= 64"
+    assert dtype_str == "f16", "V4.2 currently only supports f16"
+    assert BLOCK_N % 16 == 0, f"BLOCK_N ({BLOCK_N}) must be divisible by 16"
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    CAUSAL = causal
+    STRIDE_TOKEN = NUM_HEADS * HEAD_DIM
+
+    # ---- Bank-conflict-free LDS strides ----
+    K_STRIDE = HEAD_DIM + 2   # 130 for HD=128
+    VT_STRIDE = BLOCK_N + 2   # 34 for BLOCK_N=32
+
+    # ---- Vectorized cooperative load constants ----
+    VEC_WIDTH = 8
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    assert BLOCK_M % ROWS_PER_BATCH_LOAD == 0
+    NUM_BATCHES_Q = BLOCK_M // ROWS_PER_BATCH_LOAD
+
+    # For KV tile (32 rows with 256 threads)
+    if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+        NUM_BATCHES_KV = 1
+        KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+    else:
+        assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0
+        NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+        KV_NEEDS_GUARD = False
+
+    # LDS sizes
+    LDS_Q_SIZE = BLOCK_M * HEAD_DIM
+    LDS_KV_SIZE = max(BLOCK_N * K_STRIDE, HEAD_DIM * VT_STRIDE)
+    LDS_P_SIZE = BLOCK_M * BLOCK_N  # 64*32 = 2048
+
+    allocator = SmemAllocator(None, arch=gpu_arch)
+    _state = {}
+
+    class _FlashAttentionV4_2(flir.MlirModule):
+        GPU_MODULE_NAME = f"flash_attn_v4_2_{dtype_str}"
+        GPU_MODULE_TARGETS = [f'#rocdl.target<chip = "{gpu_arch}", abi = "500">']
+
+        def init_gpu_module(self):
+            elem_type = T.f16()
+            _state["elem_type"] = elem_type
+            _state["lds_q"] = allocator.allocate_array(elem_type, LDS_Q_SIZE)
+            _state["lds_kv"] = allocator.allocate_array(elem_type, LDS_KV_SIZE)
+            _state["lds_p"] = allocator.allocate_array(elem_type, LDS_P_SIZE)
+            allocator.finalize()
+
+        @flir.kernel
+        def flash_attention_v4_2_kernel(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            seq_len: lambda: T.index(),
+        ):
+            compute_type = T.f32()
+            elem_type = _state["elem_type"]
+            fm_fast = flir.arith.FastMathFlags.fast
+
+            v4f16_type = ir.VectorType.get([4], elem_type)
+            v4f32_type = ir.VectorType.get([4], compute_type)
+            v8f16_type = ir.VectorType.get([VEC_WIDTH], elem_type)
+
+            seq_len_v = arith.as_value(seq_len)
+
+            # ---- LDS views ----
+            base_ptr = allocator.get_base()
+            lds_q = _state["lds_q"](base_ptr).get()
+            lds_kv = _state["lds_kv"](base_ptr).get()
+            lds_p = _state["lds_p"](base_ptr).get()
+
+            # ---- Thread / block indices ----
+            block_id = flir.const_index(flir.block_idx("x"))
+            tid = flir.const_index(flir.thread_idx("x"))
+
+            # ---- Wave decomposition ----
+            c_ws = flir.const_index(WARP_SIZE)
+            wave_id = arith.as_value(flir.arith.DivUIOp(tid, c_ws).result)
+            lane = arith.as_value(flir.arith.RemUIOp(tid, c_ws).result)
+
+            # ---- MFMA lane decomposition ----
+            c16 = flir.const_index(16)
+            lane_div_16 = arith.as_value(flir.arith.DivUIOp(lane, c16).result)
+            lane_mod_16 = arith.as_value(flir.arith.RemUIOp(lane, c16).result)
+
+            # ---- Wave offsets ----
+            wave_q_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE).value
+            wave_p_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE * BLOCK_N).value
+
+            # ---- Decompose block_id ----
+            c_nh = flir.const_index(NUM_HEADS)
+            head_idx = arith.as_value(flir.arith.RemUIOp(block_id, c_nh).result)
+            temp = arith.as_value(flir.arith.DivUIOp(block_id, c_nh).result)
+            c_bm = flir.const_index(BLOCK_M)
+            num_q_tiles = arith.as_value(flir.arith.DivUIOp(seq_len_v, c_bm).result)
+            q_tile_idx = arith.as_value(flir.arith.RemUIOp(temp, num_q_tiles).result)
+            batch_idx = arith.as_value(flir.arith.DivUIOp(temp, num_q_tiles).result)
+            q_start = (arith.ArithValue(q_tile_idx) * BLOCK_M).value
+
+            # ---- Load thread decomposition ----
+            c_tpr = flir.const_index(THREADS_PER_ROW_LOAD)
+            load_row_in_batch = arith.as_value(
+                flir.arith.DivUIOp(tid, c_tpr).result
+            )
+            load_lane_in_row = arith.as_value(
+                flir.arith.RemUIOp(tid, c_tpr).result
+            )
+            load_col_base = (
+                arith.ArithValue(load_lane_in_row) * VEC_WIDTH
+            ).value
+
+            # ---- Helper: global flat index ----
+            def global_idx(token_idx, col):
+                token = (
+                    arith.ArithValue(batch_idx) * arith.ArithValue(seq_len_v)
+                    + arith.ArithValue(token_idx)
+                )
+                return (
+                    token * STRIDE_TOKEN
+                    + arith.ArithValue(head_idx) * HEAD_DIM
+                    + arith.ArithValue(col)
+                ).value
+
+            # ---- Cooperative Q load (64 rows, unpadded) ----
+            def coop_load_q():
+                for batch in range_constexpr(NUM_BATCHES_Q):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = (
+                        arith.ArithValue(q_start)
+                        + arith.ArithValue(load_row_in_batch)
+                        + row_offset
+                    ).value
+                    g_idx = global_idx(row_idx, load_col_base)
+                    vec = arith.as_value(
+                        vec_ext.load_op(v8f16_type, Q, [g_idx])
+                    )
+                    lds_row = (
+                        arith.ArithValue(load_row_in_batch) + row_offset
+                    ).value
+                    lds_idx = (
+                        arith.ArithValue(lds_row) * HEAD_DIM
+                        + arith.ArithValue(load_col_base)
+                    ).value
+                    vec_ext.store(vec, lds_q, [lds_idx])
+
+            # ---- Cooperative K load (row-major, padded stride) ----
+            def coop_load_k(tile_start):
+                for batch in range_constexpr(NUM_BATCHES_KV):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = (
+                        arith.ArithValue(tile_start)
+                        + arith.ArithValue(load_row_in_batch)
+                        + row_offset
+                    ).value
+                    g_idx = global_idx(row_idx, load_col_base)
+                    vec = arith.as_value(
+                        vec_ext.load_op(v8f16_type, K, [g_idx])
+                    )
+                    lds_row = (
+                        arith.ArithValue(load_row_in_batch) + row_offset
+                    ).value
+                    lds_idx = (
+                        arith.ArithValue(lds_row) * K_STRIDE
+                        + arith.ArithValue(load_col_base)
+                    ).value
+                    vec_ext.store(vec, lds_kv, [lds_idx])
+
+            # ---- Cooperative V load (transposed, padded stride) ----
+            def coop_load_v_transposed(tile_start):
+                for batch in range_constexpr(NUM_BATCHES_KV):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = (
+                        arith.ArithValue(tile_start)
+                        + arith.ArithValue(load_row_in_batch)
+                        + row_offset
+                    ).value
+                    g_idx = global_idx(row_idx, load_col_base)
+                    vec = arith.as_value(
+                        vec_ext.load_op(v8f16_type, V, [g_idx])
+                    )
+                    load_row = (
+                        arith.ArithValue(load_row_in_batch) + row_offset
+                    ).value
+                    # Scatter-store transposed: V[row, col+e] -> lds[(col+e)*VT_STRIDE + row]
+                    for e in range_constexpr(VEC_WIDTH):
+                        elem = arith.as_value(
+                            vec_ext.extract(vec, static_position=[e], dynamic_position=[])
+                        )
+                        col_e = (arith.ArithValue(load_col_base) + e).value
+                        lds_idx = (
+                            arith.ArithValue(col_e) * VT_STRIDE
+                            + arith.ArithValue(load_row)
+                        ).value
+                        _memref.StoreOp(elem, lds_kv, [lds_idx])
+
+            # ---- Load Q tile to LDS ----
+            coop_load_q()
+            gpu.barrier()
+
+            # ---- Preload Q A-operand packs into registers ----
+            q_a_packs = []
+            for ks in range_constexpr(K_STEPS):
+                q_lds_idx = (
+                    (arith.ArithValue(wave_q_offset)
+                     + arith.ArithValue(lane_mod_16)) * HEAD_DIM
+                    + ks * 16
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                q_a_packs.append(arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_q, [q_lds_idx])
+                ))
+
+            # ---- Constants ----
+            c_neg_inf = arith.constant(float("-inf"), type=compute_type)
+            c_zero_f = arith.constant(0.0, type=compute_type)
+            c_sm_scale = arith.constant(sm_scale, type=compute_type)
+            c_log2e = arith.constant(1.4426950408889634, type=compute_type)
+            c_zero_v4f32 = arith.as_value(
+                arith.constant_vector(0.0, v4f32_type)
+            )
+
+            # ---- Init loop-carried state ----
+            # m[4], l[4], o_accs[K_STEPS]
+            init_args = []
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_neg_inf))
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_zero_f))
+            for _ in range_constexpr(K_STEPS):
+                init_args.append(c_zero_v4f32)
+
+            # ---- KV loop upper bound ----
+            # Causal early-exit: last Q row = q_start + BLOCK_M - 1,
+            # so only need KV positions 0 .. q_start + BLOCK_M - 1.
+            # q_start + BLOCK_M is always a multiple of BLOCK_N (64 % 32 == 0).
+            if CAUSAL:
+                kv_upper = (arith.ArithValue(q_start) + BLOCK_M).value
+            else:
+                kv_upper = seq_len_v
+
+            # ---- KV loop (step BLOCK_N=32) ----
+            with scf.for_(0, kv_upper, BLOCK_N, iter_args=init_args) as loop:
+                kv_start = arith.as_value(loop.induction_variable)
+                m_old = [arith.as_value(loop.inner_iter_args[i]) for i in range(4)]
+                l_old = [arith.as_value(loop.inner_iter_args[4 + i]) for i in range(4)]
+                o_accs = [arith.as_value(loop.inner_iter_args[8 + ds]) for ds in range(K_STEPS)]
+
+                # ==== Cooperative K load -> LDS_KV (32 rows, padded stride) ====
+                coop_load_k(kv_start)
+                gpu.barrier()
+
+                # ==== Q @ K^T via MFMA -> S[16, 32] ====
+                # Two MFMA outputs: s_acc[0] for KV cols 0..15, s_acc[1] for KV cols 16..31
+                s_accs = [c_zero_v4f32, c_zero_v4f32]
+                for ks in range_constexpr(K_STEPS):
+                    a_pack = q_a_packs[ks]
+                    for nm in range_constexpr(N_MFMA):
+                        # B operand (K^T): K row = nm*16 + lane_mod_16
+                        k_row = nm * 16
+                        k_lds_idx = (
+                            (arith.ArithValue(lane_mod_16) + k_row) * K_STRIDE
+                            + ks * 16
+                            + arith.ArithValue(lane_div_16) * 4
+                        ).value
+                        b_pack = arith.as_value(
+                            vec_ext.load_op(v4f16_type, lds_kv, [k_lds_idx])
+                        )
+                        s_accs[nm] = arith.as_value(
+                            rocdl.mfma_f32_16x16x16f16(
+                                v4f32_type, [a_pack, b_pack, s_accs[nm], 0, 0, 0]
+                            )
+                        )
+
+                # ==== Online softmax over 32 positions ====
+                # For each row ii (0..3): have values at lane_mod_16 in s_accs[0] and s_accs[1]
+                # Need max and sum over all 32 positions
+                s_vals_lo = []  # from s_accs[0], KV cols 0..15
+                s_vals_hi = []  # from s_accs[1], KV cols 16..31
+                for ii in range_constexpr(4):
+                    s_lo = arith.as_value(
+                        vec_ext.extract(s_accs[0], static_position=[ii], dynamic_position=[])
+                    )
+                    s_lo = arith.as_value(
+                        flir.arith.MulFOp(s_lo, arith.as_value(c_sm_scale), fastmath=fm_fast).result
+                    )
+                    s_hi = arith.as_value(
+                        vec_ext.extract(s_accs[1], static_position=[ii], dynamic_position=[])
+                    )
+                    s_hi = arith.as_value(
+                        flir.arith.MulFOp(s_hi, arith.as_value(c_sm_scale), fastmath=fm_fast).result
+                    )
+
+                    if CAUSAL:
+                        q_row = (
+                            arith.ArithValue(q_start)
+                            + arith.ArithValue(wave_q_offset)
+                            + arith.ArithValue(lane_div_16) * 4
+                            + ii
+                        ).value
+                        # Low half: KV col = kv_start + lane_mod_16
+                        kv_col_lo = (arith.ArithValue(kv_start) + arith.ArithValue(lane_mod_16)).value
+                        # High half: KV col = kv_start + 16 + lane_mod_16
+                        kv_col_hi = (arith.ArithValue(kv_start) + 16 + arith.ArithValue(lane_mod_16)).value
+
+                        q_row_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), q_row).result)
+                        kv_lo_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), kv_col_lo).result)
+                        kv_hi_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), kv_col_hi).result)
+
+                        is_masked_lo = arith.as_value(
+                            flir.arith.CmpIOp(
+                                flir.arith.CmpIPredicate.ugt, kv_lo_i64, q_row_i64,
+                            ).result
+                        )
+                        is_masked_hi = arith.as_value(
+                            flir.arith.CmpIOp(
+                                flir.arith.CmpIPredicate.ugt, kv_hi_i64, q_row_i64,
+                            ).result
+                        )
+                        s_lo = arith.as_value(
+                            flir.arith.SelectOp(is_masked_lo, arith.as_value(c_neg_inf), s_lo).result
+                        )
+                        s_hi = arith.as_value(
+                            flir.arith.SelectOp(is_masked_hi, arith.as_value(c_neg_inf), s_hi).result
+                        )
+
+                    s_vals_lo.append(s_lo)
+                    s_vals_hi.append(s_hi)
+
+                width_i32 = arith.as_value(arith.constant(WARP_SIZE, type=T.i32()))
+                m_new = [None] * 4
+                corr = [None] * 4
+                p_vals_lo = [None] * 4
+                p_vals_hi = [None] * 4
+                l_new = [None] * 4
+
+                for ii in range_constexpr(4):
+                    # Max over 32 positions: max of lo-half and hi-half
+                    row_max_lo = s_vals_lo[ii]
+                    row_max_hi = s_vals_hi[ii]
+
+                    # Reduce lo-half within 16 lanes
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_max_lo, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_max_lo = arith.as_value(
+                            flir.arith.MaximumFOp(row_max_lo, peer).result
+                        )
+
+                    # Reduce hi-half within 16 lanes
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_max_hi, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_max_hi = arith.as_value(
+                            flir.arith.MaximumFOp(row_max_hi, peer).result
+                        )
+
+                    # Combine lo and hi maxes
+                    row_max = arith.as_value(
+                        flir.arith.MaximumFOp(row_max_lo, row_max_hi).result
+                    )
+
+                    m_new[ii] = arith.as_value(
+                        flir.arith.MaximumFOp(m_old[ii], row_max).result
+                    )
+
+                    diff_m = arith.as_value(
+                        flir.arith.SubFOp(m_old[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_m_s = arith.as_value(
+                        flir.arith.MulFOp(diff_m, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    corr[ii] = arith.as_value(flir.math.exp2(diff_m_s, fastmath=fm_fast))
+
+                    # exp2 for both halves
+                    diff_lo = arith.as_value(
+                        flir.arith.SubFOp(s_vals_lo[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_lo_s = arith.as_value(
+                        flir.arith.MulFOp(diff_lo, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    p_vals_lo[ii] = arith.as_value(flir.math.exp2(diff_lo_s, fastmath=fm_fast))
+
+                    diff_hi = arith.as_value(
+                        flir.arith.SubFOp(s_vals_hi[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_hi_s = arith.as_value(
+                        flir.arith.MulFOp(diff_hi, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    p_vals_hi[ii] = arith.as_value(flir.math.exp2(diff_hi_s, fastmath=fm_fast))
+
+                    # Sum over 32 positions
+                    row_sum_lo = p_vals_lo[ii]
+                    row_sum_hi = p_vals_hi[ii]
+
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_sum_lo, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_sum_lo = arith.as_value(
+                            flir.arith.AddFOp(row_sum_lo, peer, fastmath=fm_fast).result
+                        )
+
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_sum_hi, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_sum_hi = arith.as_value(
+                            flir.arith.AddFOp(row_sum_hi, peer, fastmath=fm_fast).result
+                        )
+
+                    row_sum = arith.as_value(
+                        flir.arith.AddFOp(row_sum_lo, row_sum_hi, fastmath=fm_fast).result
+                    )
+
+                    l_corr = arith.as_value(
+                        flir.arith.MulFOp(corr[ii], l_old[ii], fastmath=fm_fast).result
+                    )
+                    l_new[ii] = arith.as_value(
+                        flir.arith.AddFOp(l_corr, row_sum, fastmath=fm_fast).result
+                    )
+
+                # ==== Rescale O accumulators ====
+                corr_vec = arith.as_value(
+                    vec_ext.from_elements(v4f32_type, [corr[0], corr[1], corr[2], corr[3]])
+                )
+                for ds in range_constexpr(K_STEPS):
+                    o_accs[ds] = arith.as_value(
+                        flir.arith.MulFOp(o_accs[ds], corr_vec, fastmath=fm_fast).result
+                    )
+
+                # ==== P store to LDS_P ====
+                # P is [16, 32] per wave. Two 16x16 blocks: lo (cols 0..15) and hi (cols 16..31)
+                for ii in range_constexpr(4):
+                    p_lo_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, p_vals_lo[ii]).result
+                    )
+                    p_hi_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, p_vals_hi[ii]).result
+                    )
+                    p_row = (arith.ArithValue(lane_div_16) * 4 + ii).value
+                    # Lo: cols 0..15
+                    p_lds_lo = (
+                        arith.ArithValue(wave_p_offset)
+                        + arith.ArithValue(p_row) * BLOCK_N
+                        + arith.ArithValue(lane_mod_16)
+                    ).value
+                    _memref.StoreOp(p_lo_f16, lds_p, [p_lds_lo])
+                    # Hi: cols 16..31
+                    p_lds_hi = (
+                        arith.ArithValue(wave_p_offset)
+                        + arith.ArithValue(p_row) * BLOCK_N
+                        + 16
+                        + arith.ArithValue(lane_mod_16)
+                    ).value
+                    _memref.StoreOp(p_hi_f16, lds_p, [p_lds_hi])
+
+                # ==== Barrier: ensure all waves done reading K ====
+                gpu.barrier()
+
+                # ==== Cooperative V load (transposed) ====
+                coop_load_v_transposed(kv_start)
+                gpu.barrier()
+
+                # ==== P @ V via MFMA ====
+                # P[16, 32] @ V[32, 16chunk] = O[16, 16chunk]
+                # Split K=32 into two halves: P_lo[16,16] @ V_top[16,16] + P_hi[16,16] @ V_bot[16,16]
+
+                # Load P A-operand packs: P_lo and P_hi
+                p_a_lo_idx = (
+                    arith.ArithValue(wave_p_offset)
+                    + arith.ArithValue(lane_mod_16) * BLOCK_N
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                p_pack_lo = arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_p, [p_a_lo_idx])
+                )
+
+                p_a_hi_idx = (
+                    arith.ArithValue(wave_p_offset)
+                    + arith.ArithValue(lane_mod_16) * BLOCK_N
+                    + 16
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                p_pack_hi = arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_p, [p_a_hi_idx])
+                )
+
+                for ds in range_constexpr(K_STEPS):
+                    # V_top: V rows 0..15, B-operand from transposed LDS
+                    v_top_idx = (
+                        (ds * 16 + arith.ArithValue(lane_mod_16)) * VT_STRIDE
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    v_top = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_kv, [v_top_idx])
+                    )
+                    # Accumulate P_lo @ V_top
+                    o_accs[ds] = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(
+                            v4f32_type, [p_pack_lo, v_top, o_accs[ds], 0, 0, 0]
+                        )
+                    )
+
+                    # V_bot: V rows 16..31, B-operand from transposed LDS
+                    v_bot_idx = (
+                        (ds * 16 + arith.ArithValue(lane_mod_16)) * VT_STRIDE
+                        + 16
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    v_bot = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_kv, [v_bot_idx])
+                    )
+                    # Accumulate P_hi @ V_bot
+                    o_accs[ds] = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(
+                            v4f32_type, [p_pack_hi, v_bot, o_accs[ds], 0, 0, 0]
+                        )
+                    )
+
+                # ==== Barrier: ensure all waves done reading V ====
+                gpu.barrier()
+
+                # ==== Yield ====
+                yield_args = m_new + l_new + o_accs
+                scf_yield(yield_args)
+
+            # ---- Normalize and store O ----
+            m_finals = [arith.as_value(loop.results[i]) for i in range(4)]
+            l_finals = [arith.as_value(loop.results[4 + i]) for i in range(4)]
+            o_finals = [arith.as_value(loop.results[8 + ds]) for ds in range(K_STEPS)]
+
+            for ds in range_constexpr(K_STEPS):
+                for ii in range_constexpr(4):
+                    o_val = arith.as_value(
+                        vec_ext.extract(o_finals[ds], static_position=[ii], dynamic_position=[])
+                    )
+                    o_norm = arith.as_value(
+                        flir.arith.DivFOp(o_val, l_finals[ii], fastmath=fm_fast).result
+                    )
+                    o_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, o_norm).result
+                    )
+                    q_row = (
+                        arith.ArithValue(q_start)
+                        + arith.ArithValue(wave_q_offset)
+                        + arith.ArithValue(lane_div_16) * 4
+                        + ii
+                    ).value
+                    d_col = (flir.const_index(ds * 16) + arith.ArithValue(lane_mod_16)).value
+                    o_global = global_idx(q_row, d_col)
+                    _memref.StoreOp(o_f16, O, [o_global])
+
+        @flir.jit
+        def __call__(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            batch_size: lambda: T.index(),
+            seq_len: lambda: T.index(),
+        ):
+            c1 = arith.as_value(flir.arith_ext.index(1))
+            c_nh = arith.as_value(flir.arith_ext.index(NUM_HEADS))
+            c_bm = arith.as_value(flir.arith_ext.index(BLOCK_M))
+            bs_val = arith.as_value(batch_size)
+            sl_val = arith.as_value(seq_len)
+            num_q_tiles = arith.as_value(
+                flir.arith.DivUIOp(sl_val, c_bm).result
+            )
+            bs_qt = arith.as_value(
+                flir.arith.MulIOp(bs_val, num_q_tiles).result
+            )
+            grid_x = arith.as_value(
+                flir.arith.MulIOp(bs_qt, c_nh).result
+            )
+            bx = arith.as_value(flir.arith_ext.index(BLOCK_SIZE))
+            flir.gpu_ext.LaunchFuncOp(
+                [self.GPU_MODULE_NAME, KERNEL_NAME],
+                grid_size=(grid_x, c1, c1),
+                block_size=(bx, c1, c1),
+                kernel_operands=[Q, K, V, O, seq_len],
+            )
+
+    return _FlashAttentionV4_2()

--- a/kernels/flash_attention_v4_3.py
+++ b/kernels/flash_attention_v4_3.py
@@ -1,0 +1,650 @@
+"""Flash Attention V4.3 kernel builder for FlyDSL.
+
+V4.3 optimization over V4.2:
+- Q loaded directly from global memory to MFMA registers (no Q in LDS).
+  LDS = KV(8.5KB) + P(4KB) = 12.5KB (was 29KB in V4.2).
+  This enables 4 workgroups/CU -> 4 waves/SIMD (was 2 waves/SIMD).
+- Eliminates 2 barriers (Q store + Q preload sync).
+
+All other optimizations from V4.2:
+- BLOCK_N=32 (vs 16): halves KV iterations and barriers
+- Q@K^T produces [16,32] via two MFMA 16x16x16 in N dimension
+- P@V uses K=32 via two MFMA 16x16x16 in K dimension
+- Softmax over 32 positions per row (two 16-wide groups)
+- V stored transposed in LDS with bank-conflict-free padding (from V4.1)
+- Causal early-exit
+
+Tile config: BLOCK_M=64, BLOCK_N=32, 4 waves (256 threads), mfma_f32_16x16x16f16.
+
+Layout: Q/K/V/O are 1D flattened from BSHD (batch, seq_len, num_heads, head_dim).
+Grid:   (batch * num_q_tiles * num_heads,) where num_q_tiles = seq_len / BLOCK_M.
+Block:  (256,) -- 4 waves of 64 on AMD (wave64).
+
+Requires: head_dim % 16 == 0, seq_len % 64 == 0, head_dim >= 64.
+"""
+
+import math
+
+from flydsl.dialects.ext import flir, arith, gpu, scf, rocdl
+from flydsl.dialects.ext import vector as vec_ext
+from flydsl.dialects.ext.python_control_flow import range_constexpr
+from flydsl.dialects.ext.scf import yield_ as scf_yield
+from _mlir.dialects import memref as _memref
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils import SmemAllocator
+from _mlir import ir
+import _mlir.extras.types as T
+
+
+KERNEL_NAME = "flash_attention_v4_3_kernel"
+
+
+def build_flash_attention_v4_3_module(
+    num_heads,
+    head_dim,
+    causal=True,
+    dtype_str="f16",
+    sm_scale=None,
+):
+    """Build a FlyDSL Flash Attention V4.3 module (LDS overlay).
+
+    Args:
+        num_heads: Number of attention heads.
+        head_dim: Dimension per head (must be divisible by 16, >= 64).
+        causal: Whether to apply causal mask.
+        dtype_str: "f16" (bf16 not yet supported).
+        sm_scale: Softmax scale (default: 1/sqrt(head_dim)).
+
+    Returns:
+        MlirModule compilable via ``flydsl.compile(module)``.
+    """
+    gpu_arch = get_hip_arch()
+    DYN = ir.ShapedType.get_dynamic_size()
+
+    BLOCK_M = 64
+    BLOCK_N = 32   # *** doubled from V4.1 ***
+    NUM_WAVES = 4
+    WARP_SIZE = 64
+    BLOCK_SIZE = NUM_WAVES * WARP_SIZE  # 256
+    ROWS_PER_WAVE = BLOCK_M // NUM_WAVES  # 16
+    K_STEPS = head_dim // 16
+    # Number of 16-wide MFMA columns in Q@K^T N-dimension
+    N_MFMA = BLOCK_N // 16  # 2
+
+    assert head_dim % 16 == 0, f"head_dim ({head_dim}) must be divisible by 16"
+    assert head_dim >= 64, f"head_dim ({head_dim}) must be >= 64"
+    assert dtype_str == "f16", "V4.3 currently only supports f16"
+    assert BLOCK_N % 16 == 0, f"BLOCK_N ({BLOCK_N}) must be divisible by 16"
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    CAUSAL = causal
+    STRIDE_TOKEN = NUM_HEADS * HEAD_DIM
+
+    # ---- Bank-conflict-free LDS strides ----
+    K_STRIDE = HEAD_DIM + 2   # 130 for HD=128
+    VT_STRIDE = BLOCK_N + 2   # 34 for BLOCK_N=32
+
+    # ---- Vectorized cooperative load constants ----
+    VEC_WIDTH = 8
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    assert BLOCK_M % ROWS_PER_BATCH_LOAD == 0
+    NUM_BATCHES_Q = BLOCK_M // ROWS_PER_BATCH_LOAD
+
+    # For KV tile (32 rows with 256 threads)
+    if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+        NUM_BATCHES_KV = 1
+        KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+    else:
+        assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0
+        NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+        KV_NEEDS_GUARD = False
+
+    # LDS sizes (element counts, f16 = 2 bytes each)
+    # No Q in LDS — loaded directly from global memory to MFMA registers
+    LDS_KV_SIZE = max(BLOCK_N * K_STRIDE, HEAD_DIM * VT_STRIDE)  # 4352 elements = 8704 bytes
+    LDS_P_SIZE = BLOCK_M * BLOCK_N           # 2048 elements = 4096 bytes
+
+    allocator = SmemAllocator(None, arch=gpu_arch)
+    _state = {}
+
+    class _FlashAttentionV4_3(flir.MlirModule):
+        GPU_MODULE_NAME = f"flash_attn_v4_3_{dtype_str}"
+        GPU_MODULE_TARGETS = [f'#rocdl.target<chip = "{gpu_arch}", abi = "500">']
+
+        def init_gpu_module(self):
+            elem_type = T.f16()
+            _state["elem_type"] = elem_type
+            _state["lds_kv"] = allocator.allocate_array(elem_type, LDS_KV_SIZE)
+            _state["lds_p"] = allocator.allocate_array(elem_type, LDS_P_SIZE)
+            allocator.finalize()
+
+        @flir.kernel
+        def flash_attention_v4_3_kernel(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            seq_len: lambda: T.index(),
+        ):
+            compute_type = T.f32()
+            elem_type = _state["elem_type"]
+            fm_fast = flir.arith.FastMathFlags.fast
+
+            v4f16_type = ir.VectorType.get([4], elem_type)
+            v4f32_type = ir.VectorType.get([4], compute_type)
+            v8f16_type = ir.VectorType.get([VEC_WIDTH], elem_type)
+
+            seq_len_v = arith.as_value(seq_len)
+
+            # ---- LDS views (KV + P only, no Q in LDS) ----
+            base_ptr = allocator.get_base()
+            lds_kv = _state["lds_kv"](base_ptr).get()
+            lds_p = _state["lds_p"](base_ptr).get()
+
+            # ---- Thread / block indices ----
+            block_id = flir.const_index(flir.block_idx("x"))
+            tid = flir.const_index(flir.thread_idx("x"))
+
+            # ---- Wave decomposition ----
+            c_ws = flir.const_index(WARP_SIZE)
+            wave_id = arith.as_value(flir.arith.DivUIOp(tid, c_ws).result)
+            lane = arith.as_value(flir.arith.RemUIOp(tid, c_ws).result)
+
+            # ---- MFMA lane decomposition ----
+            c16 = flir.const_index(16)
+            lane_div_16 = arith.as_value(flir.arith.DivUIOp(lane, c16).result)
+            lane_mod_16 = arith.as_value(flir.arith.RemUIOp(lane, c16).result)
+
+            # ---- Wave offsets ----
+            wave_q_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE).value
+            wave_p_offset = (arith.ArithValue(wave_id) * ROWS_PER_WAVE * BLOCK_N).value
+
+            # ---- Decompose block_id ----
+            c_nh = flir.const_index(NUM_HEADS)
+            head_idx = arith.as_value(flir.arith.RemUIOp(block_id, c_nh).result)
+            temp = arith.as_value(flir.arith.DivUIOp(block_id, c_nh).result)
+            c_bm = flir.const_index(BLOCK_M)
+            num_q_tiles = arith.as_value(flir.arith.DivUIOp(seq_len_v, c_bm).result)
+            q_tile_idx = arith.as_value(flir.arith.RemUIOp(temp, num_q_tiles).result)
+            batch_idx = arith.as_value(flir.arith.DivUIOp(temp, num_q_tiles).result)
+            q_start = (arith.ArithValue(q_tile_idx) * BLOCK_M).value
+
+            # ---- Load thread decomposition ----
+            c_tpr = flir.const_index(THREADS_PER_ROW_LOAD)
+            load_row_in_batch = arith.as_value(
+                flir.arith.DivUIOp(tid, c_tpr).result
+            )
+            load_lane_in_row = arith.as_value(
+                flir.arith.RemUIOp(tid, c_tpr).result
+            )
+            load_col_base = (
+                arith.ArithValue(load_lane_in_row) * VEC_WIDTH
+            ).value
+
+            # ---- Helper: global flat index ----
+            def global_idx(token_idx, col):
+                token = (
+                    arith.ArithValue(batch_idx) * arith.ArithValue(seq_len_v)
+                    + arith.ArithValue(token_idx)
+                )
+                return (
+                    token * STRIDE_TOKEN
+                    + arith.ArithValue(head_idx) * HEAD_DIM
+                    + arith.ArithValue(col)
+                ).value
+
+            # ---- Cooperative K load (row-major, padded stride) ----
+            def coop_load_k(tile_start):
+                for batch in range_constexpr(NUM_BATCHES_KV):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = (
+                        arith.ArithValue(tile_start)
+                        + arith.ArithValue(load_row_in_batch)
+                        + row_offset
+                    ).value
+                    g_idx = global_idx(row_idx, load_col_base)
+                    vec = arith.as_value(
+                        vec_ext.load_op(v8f16_type, K, [g_idx])
+                    )
+                    lds_row = (
+                        arith.ArithValue(load_row_in_batch) + row_offset
+                    ).value
+                    lds_idx = (
+                        arith.ArithValue(lds_row) * K_STRIDE
+                        + arith.ArithValue(load_col_base)
+                    ).value
+                    vec_ext.store(vec, lds_kv, [lds_idx])
+
+            # ---- Cooperative V load (transposed, padded stride) ----
+            def coop_load_v_transposed(tile_start):
+                for batch in range_constexpr(NUM_BATCHES_KV):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = (
+                        arith.ArithValue(tile_start)
+                        + arith.ArithValue(load_row_in_batch)
+                        + row_offset
+                    ).value
+                    g_idx = global_idx(row_idx, load_col_base)
+                    vec = arith.as_value(
+                        vec_ext.load_op(v8f16_type, V, [g_idx])
+                    )
+                    load_row = (
+                        arith.ArithValue(load_row_in_batch) + row_offset
+                    ).value
+                    # Scatter-store transposed: V[row, col+e] -> lds_kv[(col+e)*VT_STRIDE + row]
+                    for e in range_constexpr(VEC_WIDTH):
+                        elem = arith.as_value(
+                            vec_ext.extract(vec, static_position=[e], dynamic_position=[])
+                        )
+                        col_e = (arith.ArithValue(load_col_base) + e).value
+                        lds_idx = (
+                            arith.ArithValue(col_e) * VT_STRIDE
+                            + arith.ArithValue(load_row)
+                        ).value
+                        _memref.StoreOp(elem, lds_kv, [lds_idx])
+
+            # ---- Load Q directly from global memory to MFMA registers ----
+            # Each MFMA lane (b=lane_div_16, n=lane_mod_16) loads v4f16 from
+            # Q[q_start + wave_offset + n, ks*16 + b*4 : ks*16 + b*4 + 4].
+            # No LDS needed for Q — eliminates overlay race condition.
+            q_row = (
+                arith.ArithValue(q_start)
+                + arith.ArithValue(wave_q_offset)
+                + arith.ArithValue(lane_mod_16)
+            ).value
+            q_a_packs = []
+            for ks in range_constexpr(K_STEPS):
+                q_col = flir.const_index(ks * 16 + 0)
+                q_col = (arith.ArithValue(q_col) + arith.ArithValue(lane_div_16) * 4).value
+                g_idx = global_idx(q_row, q_col)
+                q_a_packs.append(arith.as_value(
+                    vec_ext.load_op(v4f16_type, Q, [g_idx])
+                ))
+
+            # ---- Constants ----
+            c_neg_inf = arith.constant(float("-inf"), type=compute_type)
+            c_zero_f = arith.constant(0.0, type=compute_type)
+            c_sm_scale = arith.constant(sm_scale, type=compute_type)
+            c_log2e = arith.constant(1.4426950408889634, type=compute_type)
+            c_zero_v4f32 = arith.as_value(
+                arith.constant_vector(0.0, v4f32_type)
+            )
+
+            # ---- Init loop-carried state ----
+            # m[4], l[4], o_accs[K_STEPS]
+            init_args = []
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_neg_inf))
+            for _ in range_constexpr(4):
+                init_args.append(arith.as_value(c_zero_f))
+            for _ in range_constexpr(K_STEPS):
+                init_args.append(c_zero_v4f32)
+
+            # ---- KV loop upper bound ----
+            # Causal early-exit: last Q row = q_start + BLOCK_M - 1,
+            # so only need KV positions 0 .. q_start + BLOCK_M - 1.
+            # q_start + BLOCK_M is always a multiple of BLOCK_N (64 % 32 == 0).
+            if CAUSAL:
+                kv_upper = (arith.ArithValue(q_start) + BLOCK_M).value
+            else:
+                kv_upper = seq_len_v
+
+            # ---- KV loop (step BLOCK_N=32) ----
+            with scf.for_(0, kv_upper, BLOCK_N, iter_args=init_args) as loop:
+                kv_start = arith.as_value(loop.induction_variable)
+                m_old = [arith.as_value(loop.inner_iter_args[i]) for i in range(4)]
+                l_old = [arith.as_value(loop.inner_iter_args[4 + i]) for i in range(4)]
+                o_accs = [arith.as_value(loop.inner_iter_args[8 + ds]) for ds in range(K_STEPS)]
+
+                # ==== Cooperative K load -> LDS_KV (32 rows, padded stride) ====
+                coop_load_k(kv_start)
+                gpu.barrier()
+
+                # ==== Q @ K^T via MFMA -> S[16, 32] ====
+                # Two MFMA outputs: s_acc[0] for KV cols 0..15, s_acc[1] for KV cols 16..31
+                s_accs = [c_zero_v4f32, c_zero_v4f32]
+                for ks in range_constexpr(K_STEPS):
+                    a_pack = q_a_packs[ks]
+                    for nm in range_constexpr(N_MFMA):
+                        # B operand (K^T): K row = nm*16 + lane_mod_16
+                        k_row = nm * 16
+                        k_lds_idx = (
+                            (arith.ArithValue(lane_mod_16) + k_row) * K_STRIDE
+                            + ks * 16
+                            + arith.ArithValue(lane_div_16) * 4
+                        ).value
+                        b_pack = arith.as_value(
+                            vec_ext.load_op(v4f16_type, lds_kv, [k_lds_idx])
+                        )
+                        s_accs[nm] = arith.as_value(
+                            rocdl.mfma_f32_16x16x16f16(
+                                v4f32_type, [a_pack, b_pack, s_accs[nm], 0, 0, 0]
+                            )
+                        )
+
+                # ==== Online softmax over 32 positions ====
+                # For each row ii (0..3): have values at lane_mod_16 in s_accs[0] and s_accs[1]
+                # Need max and sum over all 32 positions
+                s_vals_lo = []  # from s_accs[0], KV cols 0..15
+                s_vals_hi = []  # from s_accs[1], KV cols 16..31
+                for ii in range_constexpr(4):
+                    s_lo = arith.as_value(
+                        vec_ext.extract(s_accs[0], static_position=[ii], dynamic_position=[])
+                    )
+                    s_lo = arith.as_value(
+                        flir.arith.MulFOp(s_lo, arith.as_value(c_sm_scale), fastmath=fm_fast).result
+                    )
+                    s_hi = arith.as_value(
+                        vec_ext.extract(s_accs[1], static_position=[ii], dynamic_position=[])
+                    )
+                    s_hi = arith.as_value(
+                        flir.arith.MulFOp(s_hi, arith.as_value(c_sm_scale), fastmath=fm_fast).result
+                    )
+
+                    if CAUSAL:
+                        q_row = (
+                            arith.ArithValue(q_start)
+                            + arith.ArithValue(wave_q_offset)
+                            + arith.ArithValue(lane_div_16) * 4
+                            + ii
+                        ).value
+                        # Low half: KV col = kv_start + lane_mod_16
+                        kv_col_lo = (arith.ArithValue(kv_start) + arith.ArithValue(lane_mod_16)).value
+                        # High half: KV col = kv_start + 16 + lane_mod_16
+                        kv_col_hi = (arith.ArithValue(kv_start) + 16 + arith.ArithValue(lane_mod_16)).value
+
+                        q_row_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), q_row).result)
+                        kv_lo_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), kv_col_lo).result)
+                        kv_hi_i64 = arith.as_value(flir.arith.IndexCastOp(T.i64(), kv_col_hi).result)
+
+                        is_masked_lo = arith.as_value(
+                            flir.arith.CmpIOp(
+                                flir.arith.CmpIPredicate.ugt, kv_lo_i64, q_row_i64,
+                            ).result
+                        )
+                        is_masked_hi = arith.as_value(
+                            flir.arith.CmpIOp(
+                                flir.arith.CmpIPredicate.ugt, kv_hi_i64, q_row_i64,
+                            ).result
+                        )
+                        s_lo = arith.as_value(
+                            flir.arith.SelectOp(is_masked_lo, arith.as_value(c_neg_inf), s_lo).result
+                        )
+                        s_hi = arith.as_value(
+                            flir.arith.SelectOp(is_masked_hi, arith.as_value(c_neg_inf), s_hi).result
+                        )
+
+                    s_vals_lo.append(s_lo)
+                    s_vals_hi.append(s_hi)
+
+                width_i32 = arith.as_value(arith.constant(WARP_SIZE, type=T.i32()))
+                m_new = [None] * 4
+                corr = [None] * 4
+                p_vals_lo = [None] * 4
+                p_vals_hi = [None] * 4
+                l_new = [None] * 4
+
+                for ii in range_constexpr(4):
+                    # Max over 32 positions: max of lo-half and hi-half
+                    row_max_lo = s_vals_lo[ii]
+                    row_max_hi = s_vals_hi[ii]
+
+                    # Reduce lo-half within 16 lanes
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_max_lo, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_max_lo = arith.as_value(
+                            flir.arith.MaximumFOp(row_max_lo, peer).result
+                        )
+
+                    # Reduce hi-half within 16 lanes
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_max_hi, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_max_hi = arith.as_value(
+                            flir.arith.MaximumFOp(row_max_hi, peer).result
+                        )
+
+                    # Combine lo and hi maxes
+                    row_max = arith.as_value(
+                        flir.arith.MaximumFOp(row_max_lo, row_max_hi).result
+                    )
+
+                    m_new[ii] = arith.as_value(
+                        flir.arith.MaximumFOp(m_old[ii], row_max).result
+                    )
+
+                    diff_m = arith.as_value(
+                        flir.arith.SubFOp(m_old[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_m_s = arith.as_value(
+                        flir.arith.MulFOp(diff_m, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    corr[ii] = arith.as_value(flir.math.exp2(diff_m_s, fastmath=fm_fast))
+
+                    # exp2 for both halves
+                    diff_lo = arith.as_value(
+                        flir.arith.SubFOp(s_vals_lo[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_lo_s = arith.as_value(
+                        flir.arith.MulFOp(diff_lo, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    p_vals_lo[ii] = arith.as_value(flir.math.exp2(diff_lo_s, fastmath=fm_fast))
+
+                    diff_hi = arith.as_value(
+                        flir.arith.SubFOp(s_vals_hi[ii], m_new[ii], fastmath=fm_fast).result
+                    )
+                    diff_hi_s = arith.as_value(
+                        flir.arith.MulFOp(diff_hi, arith.as_value(c_log2e), fastmath=fm_fast).result
+                    )
+                    p_vals_hi[ii] = arith.as_value(flir.math.exp2(diff_hi_s, fastmath=fm_fast))
+
+                    # Sum over 32 positions
+                    row_sum_lo = p_vals_lo[ii]
+                    row_sum_hi = p_vals_hi[ii]
+
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_sum_lo, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_sum_lo = arith.as_value(
+                            flir.arith.AddFOp(row_sum_lo, peer, fastmath=fm_fast).result
+                        )
+
+                    for sh in [8, 4, 2, 1]:
+                        sh_i32 = arith.as_value(arith.constant(sh, type=T.i32()))
+                        peer = arith.as_value(
+                            gpu.ShuffleOp(row_sum_hi, sh_i32, width_i32, mode="xor").shuffleResult
+                        )
+                        row_sum_hi = arith.as_value(
+                            flir.arith.AddFOp(row_sum_hi, peer, fastmath=fm_fast).result
+                        )
+
+                    row_sum = arith.as_value(
+                        flir.arith.AddFOp(row_sum_lo, row_sum_hi, fastmath=fm_fast).result
+                    )
+
+                    l_corr = arith.as_value(
+                        flir.arith.MulFOp(corr[ii], l_old[ii], fastmath=fm_fast).result
+                    )
+                    l_new[ii] = arith.as_value(
+                        flir.arith.AddFOp(l_corr, row_sum, fastmath=fm_fast).result
+                    )
+
+                # ==== Rescale O accumulators ====
+                corr_vec = arith.as_value(
+                    vec_ext.from_elements(v4f32_type, [corr[0], corr[1], corr[2], corr[3]])
+                )
+                for ds in range_constexpr(K_STEPS):
+                    o_accs[ds] = arith.as_value(
+                        flir.arith.MulFOp(o_accs[ds], corr_vec, fastmath=fm_fast).result
+                    )
+
+                # ==== P store to LDS_P ====
+                # P is [16, 32] per wave. Two 16x16 blocks: lo (cols 0..15) and hi (cols 16..31)
+                for ii in range_constexpr(4):
+                    p_lo_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, p_vals_lo[ii]).result
+                    )
+                    p_hi_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, p_vals_hi[ii]).result
+                    )
+                    p_row = (arith.ArithValue(lane_div_16) * 4 + ii).value
+                    # Lo: cols 0..15
+                    p_lds_lo = (
+                        arith.ArithValue(wave_p_offset)
+                        + arith.ArithValue(p_row) * BLOCK_N
+                        + arith.ArithValue(lane_mod_16)
+                    ).value
+                    _memref.StoreOp(p_lo_f16, lds_p, [p_lds_lo])
+                    # Hi: cols 16..31
+                    p_lds_hi = (
+                        arith.ArithValue(wave_p_offset)
+                        + arith.ArithValue(p_row) * BLOCK_N
+                        + 16
+                        + arith.ArithValue(lane_mod_16)
+                    ).value
+                    _memref.StoreOp(p_hi_f16, lds_p, [p_lds_hi])
+
+                # ==== Barrier: ensure all waves done reading K ====
+                gpu.barrier()
+
+                # ==== Cooperative V load (transposed) ====
+                coop_load_v_transposed(kv_start)
+                gpu.barrier()
+
+                # ==== P @ V via MFMA ====
+                # P[16, 32] @ V[32, 16chunk] = O[16, 16chunk]
+                # Split K=32 into two halves: P_lo[16,16] @ V_top[16,16] + P_hi[16,16] @ V_bot[16,16]
+
+                # Load P A-operand packs: P_lo and P_hi
+                p_a_lo_idx = (
+                    arith.ArithValue(wave_p_offset)
+                    + arith.ArithValue(lane_mod_16) * BLOCK_N
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                p_pack_lo = arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_p, [p_a_lo_idx])
+                )
+
+                p_a_hi_idx = (
+                    arith.ArithValue(wave_p_offset)
+                    + arith.ArithValue(lane_mod_16) * BLOCK_N
+                    + 16
+                    + arith.ArithValue(lane_div_16) * 4
+                ).value
+                p_pack_hi = arith.as_value(
+                    vec_ext.load_op(v4f16_type, lds_p, [p_a_hi_idx])
+                )
+
+                for ds in range_constexpr(K_STEPS):
+                    # V_top: V rows 0..15, B-operand from transposed LDS
+                    v_top_idx = (
+                        (ds * 16 + arith.ArithValue(lane_mod_16)) * VT_STRIDE
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    v_top = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_kv, [v_top_idx])
+                    )
+                    # Accumulate P_lo @ V_top
+                    o_accs[ds] = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(
+                            v4f32_type, [p_pack_lo, v_top, o_accs[ds], 0, 0, 0]
+                        )
+                    )
+
+                    # V_bot: V rows 16..31, B-operand from transposed LDS
+                    v_bot_idx = (
+                        (ds * 16 + arith.ArithValue(lane_mod_16)) * VT_STRIDE
+                        + 16
+                        + arith.ArithValue(lane_div_16) * 4
+                    ).value
+                    v_bot = arith.as_value(
+                        vec_ext.load_op(v4f16_type, lds_kv, [v_bot_idx])
+                    )
+                    # Accumulate P_hi @ V_bot
+                    o_accs[ds] = arith.as_value(
+                        rocdl.mfma_f32_16x16x16f16(
+                            v4f32_type, [p_pack_hi, v_bot, o_accs[ds], 0, 0, 0]
+                        )
+                    )
+
+                # ==== Barrier: ensure all waves done reading V ====
+                gpu.barrier()
+
+                # ==== Yield ====
+                yield_args = m_new + l_new + o_accs
+                scf_yield(yield_args)
+
+            # ---- Normalize and store O ----
+            m_finals = [arith.as_value(loop.results[i]) for i in range(4)]
+            l_finals = [arith.as_value(loop.results[4 + i]) for i in range(4)]
+            o_finals = [arith.as_value(loop.results[8 + ds]) for ds in range(K_STEPS)]
+
+            for ds in range_constexpr(K_STEPS):
+                for ii in range_constexpr(4):
+                    o_val = arith.as_value(
+                        vec_ext.extract(o_finals[ds], static_position=[ii], dynamic_position=[])
+                    )
+                    o_norm = arith.as_value(
+                        flir.arith.DivFOp(o_val, l_finals[ii], fastmath=fm_fast).result
+                    )
+                    o_f16 = arith.as_value(
+                        flir.arith.TruncFOp(elem_type, o_norm).result
+                    )
+                    q_row = (
+                        arith.ArithValue(q_start)
+                        + arith.ArithValue(wave_q_offset)
+                        + arith.ArithValue(lane_div_16) * 4
+                        + ii
+                    ).value
+                    d_col = (flir.const_index(ds * 16) + arith.ArithValue(lane_mod_16)).value
+                    o_global = global_idx(q_row, d_col)
+                    _memref.StoreOp(o_f16, O, [o_global])
+
+        @flir.jit
+        def __call__(
+            self: flir.T.i64,
+            Q: lambda: T.memref(DYN, _state["elem_type"]),
+            K: lambda: T.memref(DYN, _state["elem_type"]),
+            V: lambda: T.memref(DYN, _state["elem_type"]),
+            O: lambda: T.memref(DYN, _state["elem_type"]),
+            batch_size: lambda: T.index(),
+            seq_len: lambda: T.index(),
+        ):
+            c1 = arith.as_value(flir.arith_ext.index(1))
+            c_nh = arith.as_value(flir.arith_ext.index(NUM_HEADS))
+            c_bm = arith.as_value(flir.arith_ext.index(BLOCK_M))
+            bs_val = arith.as_value(batch_size)
+            sl_val = arith.as_value(seq_len)
+            num_q_tiles = arith.as_value(
+                flir.arith.DivUIOp(sl_val, c_bm).result
+            )
+            bs_qt = arith.as_value(
+                flir.arith.MulIOp(bs_val, num_q_tiles).result
+            )
+            grid_x = arith.as_value(
+                flir.arith.MulIOp(bs_qt, c_nh).result
+            )
+            bx = arith.as_value(flir.arith_ext.index(BLOCK_SIZE))
+            flir.gpu_ext.LaunchFuncOp(
+                [self.GPU_MODULE_NAME, KERNEL_NAME],
+                grid_size=(grid_x, c1, c1),
+                block_size=(bx, c1, c1),
+                kernel_operands=[Q, K, V, O, seq_len],
+            )
+
+    return _FlashAttentionV4_3()

--- a/tests/kernels/test_flash_attention_v4.py
+++ b/tests/kernels/test_flash_attention_v4.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Flash Attention V4 (Multi-Wave MFMA) kernel test and benchmark for FlyDSL.
+
+Tests the V4 multi-wave Flash Attention kernel against PyTorch SDPA reference.
+Optionally compares performance with V3 kernels.
+
+Usage:
+    python tests/kernels/test_flash_attention_v4.py
+    python tests/kernels/test_flash_attention_v4.py --seq_len 512 --head_dim 128
+    python tests/kernels/test_flash_attention_v4.py --compare-v3
+"""
+
+import sys
+import os
+import argparse
+from pathlib import Path
+
+_repo = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo))
+
+try:
+    import torch
+    import torch.nn.functional as F
+except ImportError:
+    print("PyTorch not available")
+    sys.exit(1)
+
+if not torch.cuda.is_available():
+    print("CUDA/ROCm not available")
+    sys.exit(1)
+
+import flydsl
+from kernels.flash_attention_v4 import build_flash_attention_v4_module, KERNEL_NAME
+
+
+def pytorch_ref_attention(q, k, v, causal=True):
+    """PyTorch SDPA reference.  q/k/v: (B, S, H, D) float32 -> (B, S, H, D)."""
+    q_t = q.transpose(1, 2).float()
+    k_t = k.transpose(1, 2).float()
+    v_t = v.transpose(1, 2).float()
+    out = F.scaled_dot_product_attention(q_t, k_t, v_t, is_causal=causal)
+    return out.transpose(1, 2)
+
+
+def bench_gpu_us(fn, warmup=10, iters=50):
+    """Benchmark a GPU function, return average microseconds."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return (start.elapsed_time(end) / iters) * 1000
+
+
+def run_config(batch, seq_len, num_heads, head_dim, dtype, causal,
+               warmup, iters, v3_exe=None):
+    """Run one configuration. Returns dict with results."""
+    device = "cuda"
+    results = {}
+
+    # V4 requires seq_len divisible by BLOCK_M=64, head_dim by 16, head_dim >= 64
+    if seq_len % 64 != 0:
+        results["err"] = f"seq_len ({seq_len}) must be divisible by 64"
+        return results
+    if head_dim % 16 != 0 or head_dim < 64:
+        results["err"] = f"head_dim ({head_dim}) must be >= 64 and divisible by 16"
+        return results
+
+    try:
+        m = build_flash_attention_v4_module(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            causal=causal,
+            dtype_str="f16",
+        )
+        exe = flydsl.compile(m)
+    except Exception as e:
+        results["err"] = f"compile: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    B, S, H, D = batch, seq_len, num_heads, head_dim
+    q_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    k_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    v_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+
+    q_flat = q_4d.contiguous().view(-1)
+    k_flat = k_4d.contiguous().view(-1)
+    v_flat = v_4d.contiguous().view(-1)
+    o_flat = torch.zeros_like(q_flat)
+
+    try:
+        exe(q_flat, k_flat, v_flat, o_flat, B, S)
+        torch.cuda.synchronize()
+    except Exception as e:
+        results["err"] = f"exec: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    # PyTorch reference
+    ref_4d = pytorch_ref_attention(
+        q_4d.float(), k_4d.float(), v_4d.float(), causal=causal
+    ).to(dtype)
+    ref_flat = ref_4d.contiguous().view(-1)
+
+    # Correctness
+    o_f32 = o_flat.float()
+    ref_f32 = ref_flat.float()
+    max_err = (o_f32 - ref_f32).abs().max().item()
+    mean_err = (o_f32 - ref_f32).abs().mean().item()
+    cos_sim = F.cosine_similarity(
+        o_f32.view(-1, D), ref_f32.view(-1, D), dim=1
+    )
+    min_cos = cos_sim.min().item()
+    results["max_err"] = max_err
+    results["mean_err"] = mean_err
+    results["min_cos"] = min_cos
+
+    atol = 1e-2
+    results["passed"] = max_err < atol and min_cos > 0.99
+
+    # Benchmark V4
+    try:
+        def kernel_fn():
+            o_flat.zero_()
+            exe(q_flat, k_flat, v_flat, o_flat, B, S)
+
+        us = bench_gpu_us(kernel_fn, warmup=warmup, iters=iters)
+        s_eff = S / 2.0 if causal else float(S)
+        flops = 4.0 * S * s_eff * D * H * B
+        tflops = flops / (us * 1e-6) / 1e12
+        results["us"] = us
+        results["tflops"] = tflops
+    except Exception as e:
+        results["bench_err"] = str(e)
+
+    # Benchmark V3 for comparison
+    if v3_exe is not None:
+        try:
+            o_v3 = torch.zeros_like(q_flat)
+
+            def v3_fn():
+                o_v3.zero_()
+                v3_exe(q_flat, k_flat, v_flat, o_v3, B, S)
+
+            v3_us = bench_gpu_us(v3_fn, warmup=warmup, iters=iters)
+            v3_tflops = flops / (v3_us * 1e-6) / 1e12
+            results["v3_us"] = v3_us
+            results["v3_tflops"] = v3_tflops
+        except Exception as e:
+            results["v3_bench_err"] = str(e)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Flash Attention V4 (Multi-Wave MFMA) FlyDSL Test/Benchmark"
+    )
+    parser.add_argument("--batch", type=int, default=None)
+    parser.add_argument("--seq_len", type=int, default=None)
+    parser.add_argument("--num_heads", type=int, default=None)
+    parser.add_argument("--head_dim", type=int, default=None)
+    parser.add_argument(
+        "--dtype", type=str, default="fp16", choices=["fp16"]
+    )
+    parser.add_argument("--no-causal", action="store_true")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--compare-v3", action="store_true",
+                        help="Also benchmark V3 for comparison")
+    args = parser.parse_args()
+
+    causal = not args.no_causal
+    dtype = torch.float16
+    causal_str = "causal" if causal else "non-causal"
+
+    print("=" * 120)
+    print(f"FlyDSL Flash Attention V4 Multi-Wave MFMA ({causal_str}, fp16)")
+    print(f"  BLOCK_M=64, BLOCK_N=16, 4 waves (256 threads), mfma_f32_16x16x16f16")
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print("=" * 120)
+
+    if args.seq_len or args.head_dim or args.batch:
+        configs = [(
+            args.batch or 1,
+            args.seq_len or 128,
+            args.num_heads or 8,
+            args.head_dim or 128,
+        )]
+    else:
+        configs = [
+            (1, 64,   8,  128),
+            (1, 128,  8,  128),
+            (1, 256, 32,  128),
+            (1, 512, 32,  128),
+            (2, 128,  8,  128),
+        ]
+
+    # Pre-compile V3 if comparing
+    v3_exes = {}
+    if args.compare_v3:
+        from kernels.flash_attention_v3 import build_flash_attention_v3_module
+        for _, _, nh, hd in configs:
+            key = (nh, hd)
+            if key not in v3_exes:
+                try:
+                    m = build_flash_attention_v3_module(
+                        num_heads=nh, head_dim=hd,
+                        causal=causal, dtype_str="f16",
+                    )
+                    v3_exes[key] = flydsl.compile(m)
+                except Exception:
+                    v3_exes[key] = None
+
+    if args.compare_v3:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'V4(us)':>10s} {'V4 TFLOPS':>9s} | "
+            f"{'V3(us)':>10s} {'V3 TFLOPS':>9s} | {'Speedup':>7s}"
+        )
+    else:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'Time(us)':>10s} {'TFLOPS':>8s}"
+        )
+    print(f"\n{hdr}")
+    print("-" * len(hdr))
+
+    all_passed = True
+    for batch, seq_len, nh, hd in configs:
+        tag = f"B={batch} S={seq_len} H={nh} D={hd}"
+        try:
+            v3_exe = v3_exes.get((nh, hd)) if args.compare_v3 else None
+            r = run_config(
+                batch, seq_len, nh, hd, dtype, causal,
+                warmup=args.warmup, iters=args.iters,
+                v3_exe=v3_exe,
+            )
+            if "err" in r:
+                print(f"{tag:>38s} | {'ERROR':>6s} | {r['err'][:60]}")
+                all_passed = False
+                continue
+
+            status = "PASS" if r["passed"] else "FAIL"
+            if not r["passed"]:
+                all_passed = False
+
+            v4_us = f"{r['us']:>10.1f}" if "us" in r else "       N/A"
+            v4_tf = f"{r['tflops']:>9.3f}" if "tflops" in r else "      N/A"
+
+            if args.compare_v3 and "v3_us" in r:
+                v3_us = f"{r['v3_us']:>10.1f}"
+                v3_tf = f"{r['v3_tflops']:>9.3f}"
+                speedup = r["v3_us"] / r["us"] if r.get("us") else 0
+                sp_s = f"{speedup:>6.2f}x"
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{v4_us} {v4_tf} | {v3_us} {v3_tf} | {sp_s}"
+                )
+            else:
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{v4_us} {v4_tf}"
+                )
+        except Exception as e:
+            print(f"{tag:>38s} | {'ERROR':>6s} | {str(e)[:60]}")
+            all_passed = False
+
+    print("=" * 120)
+    if all_passed:
+        print("All tests PASSED")
+    else:
+        print("Some tests FAILED")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_flash_attention_v4_1.py
+++ b/tests/kernels/test_flash_attention_v4_1.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Flash Attention V4.1 kernel test and benchmark for FlyDSL.
+
+Tests V4.1 (Q-in-registers, transposed V, bank-conflict-free padding) against
+PyTorch SDPA reference. Optionally compares with V4.0.
+
+Usage:
+    python tests/kernels/test_flash_attention_v4_1.py
+    python tests/kernels/test_flash_attention_v4_1.py --seq_len 512 --head_dim 128
+    python tests/kernels/test_flash_attention_v4_1.py --compare-v4
+"""
+
+import sys
+import os
+import argparse
+from pathlib import Path
+
+_repo = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo))
+
+try:
+    import torch
+    import torch.nn.functional as F
+except ImportError:
+    print("PyTorch not available")
+    sys.exit(1)
+
+if not torch.cuda.is_available():
+    print("CUDA/ROCm not available")
+    sys.exit(1)
+
+import flydsl
+from kernels.flash_attention_v4_1 import build_flash_attention_v4_1_module, KERNEL_NAME
+
+
+def pytorch_ref_attention(q, k, v, causal=True):
+    """PyTorch SDPA reference.  q/k/v: (B, S, H, D) float32 -> (B, S, H, D)."""
+    q_t = q.transpose(1, 2).float()
+    k_t = k.transpose(1, 2).float()
+    v_t = v.transpose(1, 2).float()
+    out = F.scaled_dot_product_attention(q_t, k_t, v_t, is_causal=causal)
+    return out.transpose(1, 2)
+
+
+def bench_gpu_us(fn, warmup=10, iters=50):
+    """Benchmark a GPU function, return average microseconds."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return (start.elapsed_time(end) / iters) * 1000
+
+
+def run_config(batch, seq_len, num_heads, head_dim, dtype, causal,
+               warmup, iters, v4_exe=None):
+    """Run one configuration. Returns dict with results."""
+    device = "cuda"
+    results = {}
+
+    if seq_len % 64 != 0:
+        results["err"] = f"seq_len ({seq_len}) must be divisible by 64"
+        return results
+    if head_dim % 16 != 0 or head_dim < 64:
+        results["err"] = f"head_dim ({head_dim}) must be >= 64 and divisible by 16"
+        return results
+
+    try:
+        m = build_flash_attention_v4_1_module(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            causal=causal,
+            dtype_str="f16",
+        )
+        exe = flydsl.compile(m)
+    except Exception as e:
+        results["err"] = f"compile: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    B, S, H, D = batch, seq_len, num_heads, head_dim
+    q_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    k_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    v_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+
+    q_flat = q_4d.contiguous().view(-1)
+    k_flat = k_4d.contiguous().view(-1)
+    v_flat = v_4d.contiguous().view(-1)
+    o_flat = torch.zeros_like(q_flat)
+
+    try:
+        exe(q_flat, k_flat, v_flat, o_flat, B, S)
+        torch.cuda.synchronize()
+    except Exception as e:
+        results["err"] = f"exec: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    # PyTorch reference
+    ref_4d = pytorch_ref_attention(
+        q_4d.float(), k_4d.float(), v_4d.float(), causal=causal
+    ).to(dtype)
+    ref_flat = ref_4d.contiguous().view(-1)
+
+    # Correctness
+    o_f32 = o_flat.float()
+    ref_f32 = ref_flat.float()
+    max_err = (o_f32 - ref_f32).abs().max().item()
+    mean_err = (o_f32 - ref_f32).abs().mean().item()
+    cos_sim = F.cosine_similarity(
+        o_f32.view(-1, D), ref_f32.view(-1, D), dim=1
+    )
+    min_cos = cos_sim.min().item()
+    results["max_err"] = max_err
+    results["mean_err"] = mean_err
+    results["min_cos"] = min_cos
+
+    atol = 1e-2
+    results["passed"] = max_err < atol and min_cos > 0.99
+
+    # Benchmark V4.1
+    try:
+        def kernel_fn():
+            o_flat.zero_()
+            exe(q_flat, k_flat, v_flat, o_flat, B, S)
+
+        us = bench_gpu_us(kernel_fn, warmup=warmup, iters=iters)
+        s_eff = S / 2.0 if causal else float(S)
+        flops = 4.0 * S * s_eff * D * H * B
+        tflops = flops / (us * 1e-6) / 1e12
+        results["us"] = us
+        results["tflops"] = tflops
+    except Exception as e:
+        results["bench_err"] = str(e)
+
+    # Benchmark V4.0 for comparison
+    if v4_exe is not None:
+        try:
+            o_v4 = torch.zeros_like(q_flat)
+
+            def v4_fn():
+                o_v4.zero_()
+                v4_exe(q_flat, k_flat, v_flat, o_v4, B, S)
+
+            v4_us = bench_gpu_us(v4_fn, warmup=warmup, iters=iters)
+            v4_tflops = flops / (v4_us * 1e-6) / 1e12
+            results["v4_us"] = v4_us
+            results["v4_tflops"] = v4_tflops
+        except Exception as e:
+            results["v4_bench_err"] = str(e)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Flash Attention V4.1 FlyDSL Test/Benchmark"
+    )
+    parser.add_argument("--batch", type=int, default=None)
+    parser.add_argument("--seq_len", type=int, default=None)
+    parser.add_argument("--num_heads", type=int, default=None)
+    parser.add_argument("--head_dim", type=int, default=None)
+    parser.add_argument(
+        "--dtype", type=str, default="fp16", choices=["fp16"]
+    )
+    parser.add_argument("--no-causal", action="store_true")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--compare-v4", action="store_true",
+                        help="Also benchmark V4.0 for comparison")
+    args = parser.parse_args()
+
+    causal = not args.no_causal
+    dtype = torch.float16
+    causal_str = "causal" if causal else "non-causal"
+
+    print("=" * 130)
+    print(f"FlyDSL Flash Attention V4.1 ({causal_str}, fp16)")
+    print(f"  Q-in-registers, transposed V (vectorized), bank-conflict-free LDS padding")
+    print(f"  BLOCK_M=64, BLOCK_N=16, 4 waves (256 threads), mfma_f32_16x16x16f16")
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print("=" * 130)
+
+    if args.seq_len or args.head_dim or args.batch:
+        configs = [(
+            args.batch or 1,
+            args.seq_len or 128,
+            args.num_heads or 8,
+            args.head_dim or 128,
+        )]
+    else:
+        configs = [
+            (1, 64,   8,  128),
+            (1, 128,  8,  128),
+            (1, 256, 32,  128),
+            (1, 512, 32,  128),
+            (2, 128,  8,  128),
+        ]
+
+    # Pre-compile V4.0 if comparing
+    v4_exes = {}
+    if args.compare_v4:
+        from kernels.flash_attention_v4 import build_flash_attention_v4_module
+        for _, _, nh, hd in configs:
+            key = (nh, hd)
+            if key not in v4_exes:
+                try:
+                    m = build_flash_attention_v4_module(
+                        num_heads=nh, head_dim=hd,
+                        causal=causal, dtype_str="f16",
+                    )
+                    v4_exes[key] = flydsl.compile(m)
+                except Exception:
+                    v4_exes[key] = None
+
+    if args.compare_v4:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'V4.1(us)':>10s} {'V4.1 TF':>9s} | "
+            f"{'V4.0(us)':>10s} {'V4.0 TF':>9s} | {'Speedup':>7s}"
+        )
+    else:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'Time(us)':>10s} {'TFLOPS':>8s}"
+        )
+    print(f"\n{hdr}")
+    print("-" * len(hdr))
+
+    all_passed = True
+    for batch, seq_len, nh, hd in configs:
+        tag = f"B={batch} S={seq_len} H={nh} D={hd}"
+        try:
+            v4_exe = v4_exes.get((nh, hd)) if args.compare_v4 else None
+            r = run_config(
+                batch, seq_len, nh, hd, dtype, causal,
+                warmup=args.warmup, iters=args.iters,
+                v4_exe=v4_exe,
+            )
+            if "err" in r:
+                print(f"{tag:>38s} | {'ERROR':>6s} | {r['err'][:60]}")
+                all_passed = False
+                continue
+
+            status = "PASS" if r["passed"] else "FAIL"
+            if not r["passed"]:
+                all_passed = False
+
+            v41_us = f"{r['us']:>10.1f}" if "us" in r else "       N/A"
+            v41_tf = f"{r['tflops']:>9.3f}" if "tflops" in r else "      N/A"
+
+            if args.compare_v4 and "v4_us" in r:
+                v4_us = f"{r['v4_us']:>10.1f}"
+                v4_tf = f"{r['v4_tflops']:>9.3f}"
+                speedup = r["v4_us"] / r["us"] if r.get("us") else 0
+                sp_s = f"{speedup:>6.2f}x"
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{v41_us} {v41_tf} | {v4_us} {v4_tf} | {sp_s}"
+                )
+            else:
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{v41_us} {v41_tf}"
+                )
+        except Exception as e:
+            print(f"{tag:>38s} | {'ERROR':>6s} | {str(e)[:60]}")
+            all_passed = False
+
+    print("=" * 130)
+    if all_passed:
+        print("All tests PASSED")
+    else:
+        print("Some tests FAILED")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_flash_attention_v4_2.py
+++ b/tests/kernels/test_flash_attention_v4_2.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Flash Attention V4.2 kernel test and benchmark for FlyDSL.
+
+Tests V4.2 (BLOCK_N=32, transposed V, Q-in-registers) against PyTorch SDPA.
+Optionally compares with V4.1.
+
+Usage:
+    python tests/kernels/test_flash_attention_v4_2.py
+    python tests/kernels/test_flash_attention_v4_2.py --seq_len 512 --head_dim 128
+    python tests/kernels/test_flash_attention_v4_2.py --compare-v41
+"""
+
+import sys
+import argparse
+from pathlib import Path
+
+_repo = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo))
+
+try:
+    import torch
+    import torch.nn.functional as F
+except ImportError:
+    print("PyTorch not available")
+    sys.exit(1)
+
+if not torch.cuda.is_available():
+    print("CUDA/ROCm not available")
+    sys.exit(1)
+
+import flydsl
+from kernels.flash_attention_v4_2 import build_flash_attention_v4_2_module, KERNEL_NAME
+
+
+def pytorch_ref_attention(q, k, v, causal=True):
+    q_t = q.transpose(1, 2).float()
+    k_t = k.transpose(1, 2).float()
+    v_t = v.transpose(1, 2).float()
+    out = F.scaled_dot_product_attention(q_t, k_t, v_t, is_causal=causal)
+    return out.transpose(1, 2)
+
+
+def bench_gpu_us(fn, warmup=10, iters=50):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return (start.elapsed_time(end) / iters) * 1000
+
+
+def run_config(batch, seq_len, num_heads, head_dim, dtype, causal,
+               warmup, iters, prev_exe=None):
+    device = "cuda"
+    results = {}
+
+    if seq_len % 64 != 0:
+        results["err"] = f"seq_len ({seq_len}) must be divisible by 64"
+        return results
+    if head_dim % 16 != 0 or head_dim < 64:
+        results["err"] = f"head_dim ({head_dim}) must be >= 64 and divisible by 16"
+        return results
+
+    try:
+        m = build_flash_attention_v4_2_module(
+            num_heads=num_heads, head_dim=head_dim,
+            causal=causal, dtype_str="f16",
+        )
+        exe = flydsl.compile(m)
+    except Exception as e:
+        results["err"] = f"compile: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    B, S, H, D = batch, seq_len, num_heads, head_dim
+    q_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    k_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    v_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+
+    q_flat = q_4d.contiguous().view(-1)
+    k_flat = k_4d.contiguous().view(-1)
+    v_flat = v_4d.contiguous().view(-1)
+    o_flat = torch.zeros_like(q_flat)
+
+    try:
+        exe(q_flat, k_flat, v_flat, o_flat, B, S)
+        torch.cuda.synchronize()
+    except Exception as e:
+        results["err"] = f"exec: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    ref_4d = pytorch_ref_attention(
+        q_4d.float(), k_4d.float(), v_4d.float(), causal=causal
+    ).to(dtype)
+    ref_flat = ref_4d.contiguous().view(-1)
+
+    o_f32 = o_flat.float()
+    ref_f32 = ref_flat.float()
+    max_err = (o_f32 - ref_f32).abs().max().item()
+    mean_err = (o_f32 - ref_f32).abs().mean().item()
+    cos_sim = F.cosine_similarity(
+        o_f32.view(-1, D), ref_f32.view(-1, D), dim=1
+    )
+    min_cos = cos_sim.min().item()
+    results["max_err"] = max_err
+    results["mean_err"] = mean_err
+    results["min_cos"] = min_cos
+    results["passed"] = max_err < 1e-2 and min_cos > 0.99
+
+    try:
+        def kernel_fn():
+            o_flat.zero_()
+            exe(q_flat, k_flat, v_flat, o_flat, B, S)
+
+        us = bench_gpu_us(kernel_fn, warmup=warmup, iters=iters)
+        s_eff = S / 2.0 if causal else float(S)
+        flops = 4.0 * S * s_eff * D * H * B
+        tflops = flops / (us * 1e-6) / 1e12
+        results["us"] = us
+        results["tflops"] = tflops
+    except Exception as e:
+        results["bench_err"] = str(e)
+
+    if prev_exe is not None:
+        try:
+            o_prev = torch.zeros_like(q_flat)
+            def prev_fn():
+                o_prev.zero_()
+                prev_exe(q_flat, k_flat, v_flat, o_prev, B, S)
+            prev_us = bench_gpu_us(prev_fn, warmup=warmup, iters=iters)
+            prev_tflops = flops / (prev_us * 1e-6) / 1e12
+            results["prev_us"] = prev_us
+            results["prev_tflops"] = prev_tflops
+        except Exception as e:
+            results["prev_bench_err"] = str(e)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Flash Attention V4.2 FlyDSL Test/Benchmark"
+    )
+    parser.add_argument("--batch", type=int, default=None)
+    parser.add_argument("--seq_len", type=int, default=None)
+    parser.add_argument("--num_heads", type=int, default=None)
+    parser.add_argument("--head_dim", type=int, default=None)
+    parser.add_argument("--no-causal", action="store_true")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--compare-v41", action="store_true",
+                        help="Also benchmark V4.1 for comparison")
+    args = parser.parse_args()
+
+    causal = not args.no_causal
+    dtype = torch.float16
+
+    print("=" * 130)
+    print(f"FlyDSL Flash Attention V4.2 ({'causal' if causal else 'non-causal'}, fp16)")
+    print(f"  BLOCK_N=32, Q-in-registers, transposed V, bank-conflict-free LDS")
+    print(f"  BLOCK_M=64, 4 waves (256 threads), mfma_f32_16x16x16f16")
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print("=" * 130)
+
+    if args.seq_len or args.head_dim or args.batch:
+        configs = [(
+            args.batch or 1,
+            args.seq_len or 128,
+            args.num_heads or 8,
+            args.head_dim or 128,
+        )]
+    else:
+        configs = [
+            (1, 64,   8,  128),
+            (1, 128,  8,  128),
+            (1, 256, 32,  128),
+            (1, 512, 32,  128),
+            (2, 128,  8,  128),
+        ]
+
+    prev_exes = {}
+    if args.compare_v41:
+        from kernels.flash_attention_v4_1 import build_flash_attention_v4_1_module
+        for _, _, nh, hd in configs:
+            key = (nh, hd)
+            if key not in prev_exes:
+                try:
+                    m = build_flash_attention_v4_1_module(
+                        num_heads=nh, head_dim=hd,
+                        causal=causal, dtype_str="f16",
+                    )
+                    prev_exes[key] = flydsl.compile(m)
+                except Exception:
+                    prev_exes[key] = None
+
+    if args.compare_v41:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'V4.2(us)':>10s} {'V4.2 TF':>9s} | "
+            f"{'V4.1(us)':>10s} {'V4.1 TF':>9s} | {'Speedup':>7s}"
+        )
+    else:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'Time(us)':>10s} {'TFLOPS':>8s}"
+        )
+    print(f"\n{hdr}")
+    print("-" * len(hdr))
+
+    all_passed = True
+    for batch, seq_len, nh, hd in configs:
+        tag = f"B={batch} S={seq_len} H={nh} D={hd}"
+        try:
+            prev_exe = prev_exes.get((nh, hd)) if args.compare_v41 else None
+            r = run_config(
+                batch, seq_len, nh, hd, dtype, causal,
+                warmup=args.warmup, iters=args.iters,
+                prev_exe=prev_exe,
+            )
+            if "err" in r:
+                print(f"{tag:>38s} | {'ERROR':>6s} | {r['err'][:60]}")
+                all_passed = False
+                continue
+
+            status = "PASS" if r["passed"] else "FAIL"
+            if not r["passed"]:
+                all_passed = False
+
+            us_s = f"{r['us']:>10.1f}" if "us" in r else "       N/A"
+            tf_s = f"{r['tflops']:>9.3f}" if "tflops" in r else "      N/A"
+
+            if args.compare_v41 and "prev_us" in r:
+                p_us = f"{r['prev_us']:>10.1f}"
+                p_tf = f"{r['prev_tflops']:>9.3f}"
+                speedup = r["prev_us"] / r["us"] if r.get("us") else 0
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{us_s} {tf_s} | {p_us} {p_tf} | {speedup:>6.2f}x"
+                )
+            else:
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{us_s} {tf_s}"
+                )
+        except Exception as e:
+            print(f"{tag:>38s} | {'ERROR':>6s} | {str(e)[:60]}")
+            all_passed = False
+
+    print("=" * 130)
+    if all_passed:
+        print("All tests PASSED")
+    else:
+        print("Some tests FAILED")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_flash_attention_v4_3.py
+++ b/tests/kernels/test_flash_attention_v4_3.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Flash Attention V4.3 kernel test and benchmark for FlyDSL.
+
+Tests V4.3 (LDS overlay) against PyTorch SDPA.
+Optionally compares with V4.2.
+
+Usage:
+    python tests/kernels/test_flash_attention_v4_3.py
+    python tests/kernels/test_flash_attention_v4_3.py --seq_len 512 --head_dim 128
+    python tests/kernels/test_flash_attention_v4_3.py --compare-v42
+"""
+
+import sys
+import argparse
+from pathlib import Path
+
+_repo = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo))
+
+try:
+    import torch
+    import torch.nn.functional as F
+except ImportError:
+    print("PyTorch not available")
+    sys.exit(1)
+
+if not torch.cuda.is_available():
+    print("CUDA/ROCm not available")
+    sys.exit(1)
+
+import flydsl
+from kernels.flash_attention_v4_3 import build_flash_attention_v4_3_module, KERNEL_NAME
+
+
+def pytorch_ref_attention(q, k, v, causal=True):
+    q_t = q.transpose(1, 2).float()
+    k_t = k.transpose(1, 2).float()
+    v_t = v.transpose(1, 2).float()
+    out = F.scaled_dot_product_attention(q_t, k_t, v_t, is_causal=causal)
+    return out.transpose(1, 2)
+
+
+def bench_gpu_us(fn, warmup=10, iters=50):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return (start.elapsed_time(end) / iters) * 1000
+
+
+def run_config(batch, seq_len, num_heads, head_dim, dtype, causal,
+               warmup, iters, prev_exe=None):
+    device = "cuda"
+    results = {}
+
+    if seq_len % 64 != 0:
+        results["err"] = f"seq_len ({seq_len}) must be divisible by 64"
+        return results
+    if head_dim % 16 != 0 or head_dim < 64:
+        results["err"] = f"head_dim ({head_dim}) must be >= 64 and divisible by 16"
+        return results
+
+    try:
+        m = build_flash_attention_v4_3_module(
+            num_heads=num_heads, head_dim=head_dim,
+            causal=causal, dtype_str="f16",
+        )
+        exe = flydsl.compile(m)
+    except Exception as e:
+        results["err"] = f"compile: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    B, S, H, D = batch, seq_len, num_heads, head_dim
+    q_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    k_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    v_4d = torch.randn(B, S, H, D, dtype=dtype, device=device)
+
+    q_flat = q_4d.contiguous().view(-1)
+    k_flat = k_4d.contiguous().view(-1)
+    v_flat = v_4d.contiguous().view(-1)
+    o_flat = torch.zeros_like(q_flat)
+
+    try:
+        exe(q_flat, k_flat, v_flat, o_flat, B, S)
+        torch.cuda.synchronize()
+    except Exception as e:
+        results["err"] = f"exec: {e}"
+        import traceback
+        traceback.print_exc()
+        return results
+
+    ref_4d = pytorch_ref_attention(
+        q_4d.float(), k_4d.float(), v_4d.float(), causal=causal
+    ).to(dtype)
+    ref_flat = ref_4d.contiguous().view(-1)
+
+    o_f32 = o_flat.float()
+    ref_f32 = ref_flat.float()
+    max_err = (o_f32 - ref_f32).abs().max().item()
+    mean_err = (o_f32 - ref_f32).abs().mean().item()
+    cos_sim = F.cosine_similarity(
+        o_f32.view(-1, D), ref_f32.view(-1, D), dim=1
+    )
+    min_cos = cos_sim.min().item()
+    results["max_err"] = max_err
+    results["mean_err"] = mean_err
+    results["min_cos"] = min_cos
+    results["passed"] = max_err < 1e-2 and min_cos > 0.99
+
+    try:
+        def kernel_fn():
+            o_flat.zero_()
+            exe(q_flat, k_flat, v_flat, o_flat, B, S)
+
+        us = bench_gpu_us(kernel_fn, warmup=warmup, iters=iters)
+        s_eff = S / 2.0 if causal else float(S)
+        flops = 4.0 * S * s_eff * D * H * B
+        tflops = flops / (us * 1e-6) / 1e12
+        results["us"] = us
+        results["tflops"] = tflops
+    except Exception as e:
+        results["bench_err"] = str(e)
+
+    if prev_exe is not None:
+        try:
+            o_prev = torch.zeros_like(q_flat)
+            def prev_fn():
+                o_prev.zero_()
+                prev_exe(q_flat, k_flat, v_flat, o_prev, B, S)
+            prev_us = bench_gpu_us(prev_fn, warmup=warmup, iters=iters)
+            prev_tflops = flops / (prev_us * 1e-6) / 1e12
+            results["prev_us"] = prev_us
+            results["prev_tflops"] = prev_tflops
+        except Exception as e:
+            results["prev_bench_err"] = str(e)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Flash Attention V4.3 FlyDSL Test/Benchmark"
+    )
+    parser.add_argument("--batch", type=int, default=None)
+    parser.add_argument("--seq_len", type=int, default=None)
+    parser.add_argument("--num_heads", type=int, default=None)
+    parser.add_argument("--head_dim", type=int, default=None)
+    parser.add_argument("--no-causal", action="store_true")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--compare-v42", action="store_true",
+                        help="Also benchmark V4.2 for comparison")
+    args = parser.parse_args()
+
+    causal = not args.no_causal
+    dtype = torch.float16
+
+    print("=" * 130)
+    print(f"FlyDSL Flash Attention V4.3 ({'causal' if causal else 'non-causal'}, fp16)")
+    print(f"  LDS overlay: Q space reused for KV+P (16KB vs 29KB)")
+    print(f"  BLOCK_M=64, BLOCK_N=32, 4 waves (256 threads), mfma_f32_16x16x16f16")
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print("=" * 130)
+
+    if args.seq_len or args.head_dim or args.batch:
+        configs = [(
+            args.batch or 1,
+            args.seq_len or 128,
+            args.num_heads or 8,
+            args.head_dim or 128,
+        )]
+    else:
+        configs = [
+            (1, 64,   8,  128),
+            (1, 128,  8,  128),
+            (1, 256, 32,  128),
+            (1, 512, 32,  128),
+            (2, 128,  8,  128),
+        ]
+
+    prev_exes = {}
+    if args.compare_v42:
+        from kernels.flash_attention_v4_2 import build_flash_attention_v4_2_module
+        for _, _, nh, hd in configs:
+            key = (nh, hd)
+            if key not in prev_exes:
+                try:
+                    m = build_flash_attention_v4_2_module(
+                        num_heads=nh, head_dim=hd,
+                        causal=causal, dtype_str="f16",
+                    )
+                    prev_exes[key] = flydsl.compile(m)
+                except Exception:
+                    prev_exes[key] = None
+
+    if args.compare_v42:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'V4.3(us)':>10s} {'V4.3 TF':>9s} | "
+            f"{'V4.2(us)':>10s} {'V4.2 TF':>9s} | {'Speedup':>7s}"
+        )
+    else:
+        hdr = (
+            f"{'Config':>38s} | {'Status':>6s} | {'MaxErr':>8s} "
+            f"{'MinCos':>8s} | {'Time(us)':>10s} {'TFLOPS':>8s}"
+        )
+    print(f"\n{hdr}")
+    print("-" * len(hdr))
+
+    all_passed = True
+    for batch, seq_len, nh, hd in configs:
+        tag = f"B={batch} S={seq_len} H={nh} D={hd}"
+        try:
+            prev_exe = prev_exes.get((nh, hd)) if args.compare_v42 else None
+            r = run_config(
+                batch, seq_len, nh, hd, dtype, causal,
+                warmup=args.warmup, iters=args.iters,
+                prev_exe=prev_exe,
+            )
+            if "err" in r:
+                print(f"{tag:>38s} | {'ERROR':>6s} | {r['err'][:60]}")
+                all_passed = False
+                continue
+
+            status = "PASS" if r["passed"] else "FAIL"
+            if not r["passed"]:
+                all_passed = False
+
+            us_s = f"{r['us']:>10.1f}" if "us" in r else "       N/A"
+            tf_s = f"{r['tflops']:>9.3f}" if "tflops" in r else "      N/A"
+
+            if args.compare_v42 and "prev_us" in r:
+                p_us = f"{r['prev_us']:>10.1f}"
+                p_tf = f"{r['prev_tflops']:>9.3f}"
+                speedup = r["prev_us"] / r["us"] if r.get("us") else 0
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{us_s} {tf_s} | {p_us} {p_tf} | {speedup:>6.2f}x"
+                )
+            else:
+                print(
+                    f"{tag:>38s} | {status:>6s} | "
+                    f"{r['max_err']:>8.2e} {r['min_cos']:>8.5f} | "
+                    f"{us_s} {tf_s}"
+                )
+        except Exception as e:
+            print(f"{tag:>38s} | {'ERROR':>6s} | {str(e)[:60]}")
+            all_passed = False
+
+    print("=" * 130)
+    if all_passed:
+        print("All tests PASSED")
+    else:
+        print("Some tests FAILED")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add four incremental Flash Attention kernel implementations targeting AMD MI300X (GFX942) using `mfma_f32_16x16x16f16` instructions, demonstrating progressive optimization techniques.

### Kernel Evolution

| Version | Key Optimization | LDS (bytes) | Barriers/iter | S=8192 TFLOPS |
|---------|-----------------|-------------|---------------|---------------|
| V4.0 | Baseline MFMA, BLOCK_M=64, BLOCK_N=16 | 29,184 | 4 | 26 |
| V4.1 | Q-in-registers, transposed V, bank-conflict-free LDS | 29,184 | 4 | 60 |
| V4.2 | BLOCK_N=32 (halved iters), causal early-exit | 29,184 | 4 | 108 |
| V4.3 | Q from global memory (no Q in LDS) | 12,800 | 4 | 106 |

### Key Techniques
- **MFMA 16x16x16f16**: 4-wave (256 threads), wave64, v4f16/v4f32 operands
- **Bank-conflict-free LDS**: K_STRIDE=HD+2, VT_STRIDE=BN+2 (stride/2 coprime with 32 banks)
- **Cooperative vectorized loads**: v8f16 global loads, 256 threads per tile
- **Online softmax**: XOR shuffle reduction within 16-lane MFMA groups
- **Causal early-exit**: Loop bound = q_start + BLOCK_M instead of seq_len (1.6x at S=8192)
- **Q-from-global (V4.3)**: Each MFMA lane loads its v4f16 Q operand directly from global memory, eliminating 16KB Q LDS allocation and 2 barrier syncs

### Benchmark Config
- GPU: AMD Instinct MI300X
- B=1, H=64, D=128, causal, fp16
- Gap to hand-tuned ASM kernel: ~10x (ASM uses BLOCK_M=256, mfma_32x32x8, ping-pong K, AGPRs)

### Infrastructure Fixes
- `scf.py`: Fix ArithValue unwrapping in `scf.for_` yield and auto-yield paths
- `module.py`: Add `range_for_loops` lowering support for `@flir.kernel`
- `reduce.py`: Add `warp_reduce_sum` and `warp_reduce_max` reusable utilities

## Test plan
- [x] V4.0-V4.3 pass correctness tests (max_err < 1e-2, cos_sim > 0.99 vs PyTorch SDPA)
- [x] V4.3 passes reliably 5/5 runs (no intermittent failures)
- [x] Tested configs: S={64,128,256,512,8192}, H={8,32,64}, D=128