### PR TITLE
fix(build): dereference MLIR symlinks in build output

### DIFF
--- a/flir/build.sh
+++ b/flir/build.sh
@@ -132,6 +132,19 @@ find "${PYTHON_PACKAGE_DIR}" -mindepth 1 -maxdepth 1 \
     ! -name "include" \
     -exec rm -rf {} +
 
+# Dereference symlinks in _mlir so the build output is self-contained.
+# CMake's mlir_python_sources creates symlinks into the MLIR source tree;
+# these break when the source tree is absent (e.g. Docker runtime images).
+echo "Resolving symlinks in _mlir..."
+_MLIR_DIR="${PYTHON_PACKAGE_DIR}/_mlir"
+if [ -d "${_MLIR_DIR}" ]; then
+    _TMP_DIR=$(mktemp -d)
+    cp -rL "${_MLIR_DIR}" "${_TMP_DIR}/_mlir"
+    rm -rf "${_MLIR_DIR}"
+    mv "${_TMP_DIR}/_mlir" "${_MLIR_DIR}"
+    rmdir "${_TMP_DIR}"
+fi
+
 cd "${REPO_ROOT}"
 
 echo ""


### PR DESCRIPTION
## Summary
- CMake's `mlir_python_sources` creates symlinks from the build output (`_mlir/` directory) into the MLIR source tree
- These symlinks break when the source tree is absent (e.g. Docker runtime images, wheel installs in different environments)
- Adds a post-build step in `flir/build.sh` that replaces all symlinks with real file copies (`cp -rL`), making the build output self-contained

## Root Cause
When building FlyDSL wheels in a Docker builder stage and installing them in a separate runtime stage, the `_mlir/*.py` files (like `ir.py`, dialect wrappers) are symlinks pointing to paths like `/build/llvm-project/mlir_install/src/python/...` which don't exist in the runtime container. This causes `ImportError: cannot import name 'ir' from '_mlir'`.

## Fix
Added symlink dereferencing right after the CMake build completes in `flir/build.sh`, before the editable install or wheel packaging step runs.

## Test plan
- [x] Verified zero symlinks remain in `_mlir/` after build
- [x] `python3 -c "import flydsl; from _mlir import ir; print('OK')"` works
- [ ] Rebuild Docker `atom:wheels` + `atom:clean` to verify end-to-end